### PR TITLE
fix: decode CID as Cow<[u8]>

### DIFF
--- a/tests/cid.rs
+++ b/tests/cid.rs
@@ -1,4 +1,5 @@
 use std::convert::{TryFrom, TryInto};
+use std::io::Cursor;
 use std::str::FromStr;
 
 use cid::Cid;
@@ -6,7 +7,7 @@ use libipld_core::ipld::Ipld;
 use serde::de;
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
-use serde_ipld_dagcbor::{from_slice, to_vec};
+use serde_ipld_dagcbor::{from_reader, from_slice, to_vec};
 
 #[test]
 fn test_cid_struct() {
@@ -253,4 +254,15 @@ fn test_cid_non_minimally_encoded() {
     .concat();
     let tag_8_bytes_decoded: Cid = from_slice(&tag_8_bytes_encoded).unwrap();
     assert_eq!(tag_8_bytes_decoded, cid);
+}
+
+#[test]
+fn test_cid_decode_from_reader() {
+    let cid_encoded = [
+        0xd8, 0x2a, 0x49, 0x00, 0x01, 0xce, 0x01, 0x9b, 0x01, 0x02, 0x63, 0xc8,
+    ];
+    println!("vmx: cid: {:?}", cid_encoded);
+    let cid_decoded: Cid = from_reader(Cursor::new(&cid_encoded)).unwrap();
+    println!("vmx: cid: {:?}", cid_decoded);
+    assert_eq!(&cid_encoded[4..], &cid_decoded.to_bytes());
 }


### PR DESCRIPTION
The decoding of the bytes of a CID was simpified in with this change:
https://github.com/vmx/serde_ipld_dagcbor/pull/13/commits/8ce2a79603fa454fa6343ab1e204abd4c1867dbd#diff-a9463680bdf3fa7278b52b437bfbe9072e20023a015621ed23bcb589f6ccd4b5R651-R655

Decoding to a slice doesn't work when a reader is used. Hence change
the code back to using a `Cow<[u8]>`.