### PR TITLE
fix: error on undefined

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -182,7 +182,7 @@ impl<'de, 'a, R: dec::Read<'de>> serde::Deserializer<'de> for &'a mut Deserializ
                     de.reader.advance(1);
                     visitor.visit_bool(true)
                 }
-                marker::NULL | marker::UNDEFINED => {
+                marker::NULL => {
                     de.reader.advance(1);
                     visitor.visit_none()
                 }
@@ -280,7 +280,7 @@ impl<'de, 'a, R: dec::Read<'de>> serde::Deserializer<'de> for &'a mut Deserializ
         V: Visitor<'de>,
     {
         let byte = peek_one(&mut self.reader)?;
-        if byte != marker::NULL && byte != marker::UNDEFINED {
+        if byte != marker::NULL {
             let mut de = self.try_step()?;
             visitor.visit_some(&mut **de)
         } else {

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -309,6 +309,17 @@ fn invalid_string() {
     ));
 }
 
+#[test]
+fn error_on_undefined() {
+    // CBOR smple type `undefined`
+    let input = [0xf7];
+    let result = serde_ipld_dagcbor::from_slice::<Ipld>(&input);
+    assert!(matches!(
+        result.unwrap_err(),
+        DecodeError::Unsupported { .. }
+    ));
+}
+
 #[cfg(feature = "_do_not_use_its_unsafe_and_invalid_cbor")]
 #[test]
 fn do_not_use_its_unsafe_and_invalid_cbor_test() {


### PR DESCRIPTION
DAG-CBOR only supports the CBOR value `null` and not `undefined`, hence error on `undefined`. This matches the JS and Go implementation.

This could be seen as a breaking change, but the point is, that it now follows the spec (and other implementations) more closely, so it can be considered a bug fix to prevent incompatible data.

---

To me it would make sense to release this as a patch release. Though if we would do a breaking release, then I'd include other changes, like forbidding indefinite sized items.