### PR TITLE
chore: fix Clippy warnings

### DIFF
--- a/src/cbor4ii_nonpub.rs
+++ b/src/cbor4ii_nonpub.rs
@@ -28,7 +28,7 @@ pub(crate) fn peek_one<'a, R: dec::Read<'a>>(reader: &mut R) -> Result<u8, Decod
         dec::Reference::Long(buf) => buf,
         dec::Reference::Short(buf) => buf,
     };
-    let byte = buf.get(0).copied().ok_or(DecodeError::Eof)?;
+    let byte = buf.first().copied().ok_or(DecodeError::Eof)?;
     Ok(byte)
 }
 

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -225,6 +225,7 @@ fn test_option_none_roundtrip() {
 
 #[test]
 fn test_unit() {
+    #[allow(clippy::let_unit_value)]
     let unit = ();
     let v = to_vec(&unit).unwrap();
     assert_eq!(v, [0xf6], "unit is serialized as NULL.");


### PR DESCRIPTION
New Rust versions have new Clippy warnings, this commit fixes them.