### PR TITLE
fix: disallow indefinite sized items on decode

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -121,6 +121,8 @@ pub enum DecodeError<E> {
     DepthLimit,
     /// Trailing data.
     TrailingData,
+    /// Indefinite sized item was encountered.
+    IndefiniteSize,
 }
 
 impl<E> From<E> for DecodeError<E> {

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -98,7 +98,7 @@ fn test_object() {
 }
 
 #[test]
-fn test_indefinite_object() {
+fn test_indefinite_object_error() {
     let ipld: Result<Ipld, _> = de::from_slice(b"\xbfaa\x01ab\x9f\x02\x03\xff\xff");
     let mut object = BTreeMap::new();
     object.insert("a".to_string(), Ipld::Integer(1));
@@ -106,45 +106,33 @@ fn test_indefinite_object() {
         "b".to_string(),
         Ipld::List(vec![Ipld::Integer(2), Ipld::Integer(3)]),
     );
-    assert_eq!(ipld.unwrap(), Ipld::Map(object));
+    assert!(matches!(ipld.unwrap_err(), DecodeError::IndefiniteSize));
 }
 
 #[test]
-fn test_indefinite_list() {
+fn test_indefinite_list_error() {
     let ipld: Result<Ipld, _> = de::from_slice(b"\x9f\x01\x02\x03\xff");
-    assert_eq!(
-        ipld.unwrap(),
-        Ipld::List(vec![Ipld::Integer(1), Ipld::Integer(2), Ipld::Integer(3)])
-    );
+    assert!(matches!(ipld.unwrap_err(), DecodeError::IndefiniteSize));
 }
 
 #[test]
-fn test_indefinite_string() {
+fn test_indefinite_string_error() {
     let ipld: Result<Ipld, _> =
         de::from_slice(b"\x7f\x65Mary \x64Had \x62a \x67Little \x60\x64Lamb\xff");
-    assert_eq!(
-        ipld.unwrap(),
-        Ipld::String("Mary Had a Little Lamb".to_string())
-    );
+    assert!(matches!(ipld.unwrap_err(), DecodeError::IndefiniteSize));
 }
 
 #[test]
-fn test_indefinite_byte_string() {
+fn test_indefinite_byte_string_error() {
     let ipld: Result<Ipld, _> = de::from_slice(b"\x5f\x42\x01\x23\x42\x45\x67\xff");
-    assert_eq!(ipld.unwrap(), Ipld::Bytes(b"\x01#Eg".to_vec()));
+    assert!(matches!(ipld.unwrap_err(), DecodeError::IndefiniteSize));
 }
 
 #[test]
-fn test_multiple_indefinite_strings() {
+fn test_multiple_indefinite_strings_error() {
     let input = b"\x82\x7f\x65Mary \x64Had \x62a \x67Little \x60\x64Lamb\xff\x5f\x42\x01\x23\x42\x45\x67\xff";
     let ipld: Result<Ipld, _> = de::from_slice(input);
-    assert_eq!(
-        ipld.unwrap(),
-        Ipld::List(vec![
-            Ipld::String("Mary Had a Little Lamb".to_string()),
-            Ipld::Bytes(b"\x01#Eg".to_vec())
-        ])
-    );
+    assert!(matches!(ipld.unwrap_err(), DecodeError::IndefiniteSize));
 }
 
 #[test]
@@ -234,12 +222,10 @@ fn test_unit() {
 }
 
 #[test]
-fn test_variable_length_map() {
+fn test_variable_length_map_error() {
     let slice = b"\xbf\x67\x6d\x65\x73\x73\x61\x67\x65\x64\x70\x6f\x6e\x67\xff";
-    let ipld: Ipld = de::from_slice(slice).unwrap();
-    let mut map = BTreeMap::new();
-    map.insert("message".to_string(), Ipld::String("pong".to_string()));
-    assert_eq!(ipld, Ipld::Map(map))
+    let ipld: Result<Ipld, _> = de::from_slice(slice);
+    assert!(matches!(ipld.unwrap_err(), DecodeError::IndefiniteSize));
 }
 
 #[test]

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use serde_ipld_dagcbor::{from_slice, to_vec};
+use serde_ipld_dagcbor::{from_slice, to_vec, DecodeError};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 enum Enum {
@@ -80,10 +80,10 @@ enum Foo {
 }
 
 #[test]
-fn test_variable_length_array() {
+fn test_variable_length_array_error() {
     let slice = b"\x9F\x67\x72\x65\x71\x75\x69\x72\x65\xFF";
-    let value: Vec<Foo> = from_slice(slice).unwrap();
-    assert_eq!(value, [Foo::Require]);
+    let value: Result<Vec<Foo>, _> = from_slice(slice);
+    assert!(matches!(value.unwrap_err(), DecodeError::IndefiniteSize));
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]


### PR DESCRIPTION
DAG-CBOR doesn't allow indefinite sized items. Error on decode.

BREAKING CHANGE: There is an error when indefinite items are encountered during decode.

---

As we are already doing a breaking change, I thought why not finishing that business? Less features, less code, less bugs :)