### PR TITLE
fix: remove _do_not_use_its_unsafe_and_invalid_cbor feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,3 @@ serde_bytes = { version = "0.11.5", default-features = false, features = ["alloc
 [features]
 default = ["std"]
 std = ["cbor4ii/use_std", "cid/std", "serde/std", "serde_bytes/std"]
-_do_not_use_its_unsafe_and_invalid_cbor = ["std"]

--- a/src/de.rs
+++ b/src/de.rs
@@ -251,21 +251,9 @@ impl<'de, 'a, R: dec::Read<'de>> serde::Deserializer<'de> for &'a mut Deserializ
     where
         V: Visitor<'de>,
     {
-        #[cfg(not(feature = "_do_not_use_its_unsafe_and_invalid_cbor"))]
         match <Cow<str>>::decode(&mut self.reader)? {
             Cow::Borrowed(buf) => visitor.visit_borrowed_str(buf),
             Cow::Owned(buf) => visitor.visit_string(buf),
-        }
-
-        // Don't use this. This can lead to random panics and invalid CBOR.
-        #[cfg(feature = "_do_not_use_its_unsafe_and_invalid_cbor")]
-        match types::BadStr::<Cow<[u8]>>::decode(&mut self.reader)? {
-            types::BadStr(Cow::Borrowed(buf)) => {
-                visitor.visit_borrowed_str(unsafe { std::str::from_utf8_unchecked(buf) })
-            }
-            types::BadStr(Cow::Owned(buf)) => {
-                visitor.visit_string(unsafe { String::from_utf8_unchecked(buf) })
-            }
         }
     }
 

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -305,11 +305,3 @@ fn error_on_undefined() {
         DecodeError::Unsupported { .. }
     ));
 }
-
-#[cfg(feature = "_do_not_use_its_unsafe_and_invalid_cbor")]
-#[test]
-fn do_not_use_its_unsafe_and_invalid_cbor_test() {
-    let input = [0x63, 0xc5, 0x01, 0x02];
-    let result = serde_ipld_dagcbor::from_slice::<Ipld>(&input);
-    assert!(result.is_ok())
-}


### PR DESCRIPTION
The `_do_not_use_its_unsafe_and_invalid_cbor` is not used by any upstream user anymore, hence it can be removed.

BREAKING CHANGE _do_not_use_its_unsafe_and_invalid_cbor feature is removed.

Fixes #4.