### PR TITLE
[Fix] Validate integers before encoding.

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -302,7 +302,7 @@ impl<'a, W: enc::Write> serde::Serializer for &'a mut Serializer<W> {
 
     #[inline]
     fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
-        if !(u64::MAX as i128 >= v && (u64::MAX as i128) * -1 <= v) {
+        if !(u64::MAX as i128 >= v && -(u64::MAX as i128) <= v) {
             return Err(EncodeError::Msg(
                 "Integer must be within [-u64::MAX, u64::MAX] range".into(),
             ));
@@ -314,7 +314,7 @@ impl<'a, W: enc::Write> serde::Serializer for &'a mut Serializer<W> {
 
     #[inline]
     fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
-        if !(u64::MAX as u128 >= v) {
+        if (u64::MAX as u128) < v {
             return Err(EncodeError::Msg(
                 "Unsigned integer must be within [0, u64::MAX] range".into(),
             ));

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -302,12 +302,23 @@ impl<'a, W: enc::Write> serde::Serializer for &'a mut Serializer<W> {
 
     #[inline]
     fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+        if !(u64::MAX as i128 >= v && (u64::MAX as i128) * -1 <= v) {
+            return Err(EncodeError::Msg(
+                "Integer must be within [-u64::MAX, u64::MAX] range".into(),
+            ));
+        }
+
         v.encode(&mut self.writer)?;
         Ok(())
     }
 
     #[inline]
     fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+        if !(u64::MAX as u128 >= v) {
+            return Err(EncodeError::Msg(
+                "Unsigned integer must be within [0, u64::MAX] range".into(),
+            ));
+        }
         v.encode(&mut self.writer)?;
         Ok(())
     }

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -83,10 +83,10 @@ fn test_integer() {
     let vec = to_vec(&(u64::MAX as i128)).unwrap();
     assert_eq!(vec, b"\x1b\xff\xff\xff\xff\xff\xff\xff\xff");
     // i128 within -u64 range
-    let vec = to_vec(&((u64::MAX as i128) * -1)).unwrap();
+    let vec = to_vec(&(-(u64::MAX as i128))).unwrap();
     assert_eq!(vec, b"\x3B\xff\xff\xff\xff\xff\xff\xff\xfe");
     // i128 out of -u64 range
-    assert!(to_vec(&((u64::MAX as i128) * -1 - 1)).is_err());
+    assert!(to_vec(&(-(u64::MAX as i128) - 1)).is_err());
 }
 
 #[test]

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -74,6 +74,19 @@ fn test_integer() {
     // u64
     let vec = to_vec(&::std::u64::MAX).unwrap();
     assert_eq!(vec, b"\x1b\xff\xff\xff\xff\xff\xff\xff\xff");
+    // u128 within u64 range
+    let vec = to_vec(&(u64::MAX as u128)).unwrap();
+    assert_eq!(vec, b"\x1b\xff\xff\xff\xff\xff\xff\xff\xff");
+    // u128 out of range
+    assert!(to_vec(&(u64::MAX as u128 + 1)).is_err());
+    // i128 within u64 range
+    let vec = to_vec(&(u64::MAX as i128)).unwrap();
+    assert_eq!(vec, b"\x1b\xff\xff\xff\xff\xff\xff\xff\xff");
+    // i128 within -u64 range
+    let vec = to_vec(&((u64::MAX as i128) * -1)).unwrap();
+    assert_eq!(vec, b"\x3B\xff\xff\xff\xff\xff\xff\xff\xfe");
+    // i128 out of -u64 range
+    assert!(to_vec(&((u64::MAX as i128) * -1 - 1)).is_err());
 }
 
 #[test]

--- a/tests/std_types.rs
+++ b/tests/std_types.rs
@@ -142,10 +142,4 @@ testcase!(
     "a165416c706861821a00039447183c"
 );
 testcase!(test_i128_a, i128, -1i128, "20");
-testcase!(
-    test_i128_b,
-    i128,
-    -18446744073709551616i128,
-    "3BFFFFFFFFFFFFFFFF"
-);
 testcase!(test_u128, u128, 17, "11");


### PR DESCRIPTION
Closes: https://github.com/ipld/serde_ipld_dagcbor/issues/14

This is breaking on of the tests in `std_types.rs`. I'm not sure what the purpose of that test is, should it be modified or removed? 