### PR TITLE
fix: allow deserialization of large negative integers

### DIFF
--- a/tests/de.rs
+++ b/tests/de.rs
@@ -53,6 +53,15 @@ fn test_numbers3() {
 }
 
 #[test]
+fn test_numbers_large_negative() {
+    let ipld: Result<Ipld, _> =
+        de::from_slice(&[0x3b, 0xa5, 0xf7, 0x02, 0xb3, 0xa5, 0xf7, 0x02, 0xb3]);
+    let expected: i128 = -11959030306112471732;
+    assert!(expected < i128::from(i64::MIN));
+    assert_eq!(ipld.unwrap(), Ipld::Integer(expected));
+}
+
+#[test]
 fn test_bool() {
     let ipld: Result<Ipld, _> = de::from_slice(b"\xf4");
     assert_eq!(ipld.unwrap(), Ipld::Bool(false));


### PR DESCRIPTION
CBOR allows negative integers up to -2^64. They don't fit into the usual signed 64-bit integers value range. Hence we need to decode it as signed 128-bit value.

We don't need to check for the minimim value of the input as the CBOR format itself ensures that it isn't possible to encode a negative integer smaller than -2^64. It's encoded as 0x3BFFFFFFFFFFFFFFFF.