### PR TITLE
fix: support smallest possible CBOR integer

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -304,7 +304,7 @@ impl<'a, W: enc::Write> serde::Serializer for &'a mut Serializer<W> {
     fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
         if !(u64::MAX as i128 >= v && -(u64::MAX as i128 + 1) <= v) {
             return Err(EncodeError::Msg(
-                "Integer must be within [-u64::MAX, u64::MAX] range".into(),
+                "Integer must be within [-u64::MAX-1, u64::MAX] range".into(),
             ));
         }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -302,7 +302,7 @@ impl<'a, W: enc::Write> serde::Serializer for &'a mut Serializer<W> {
 
     #[inline]
     fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
-        if !(u64::MAX as i128 >= v && -(u64::MAX as i128) <= v) {
+        if !(u64::MAX as i128 >= v && -(u64::MAX as i128 + 1) <= v) {
             return Err(EncodeError::Msg(
                 "Integer must be within [-u64::MAX, u64::MAX] range".into(),
             ));

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -85,8 +85,11 @@ fn test_integer() {
     // i128 within -u64 range
     let vec = to_vec(&(-(u64::MAX as i128))).unwrap();
     assert_eq!(vec, b"\x3B\xff\xff\xff\xff\xff\xff\xff\xfe");
+    // minimum CBOR integer value
+    let vec = to_vec(&(-(u64::MAX as i128 + 1))).unwrap();
+    assert_eq!(vec, b"\x3B\xff\xff\xff\xff\xff\xff\xff\xff");
     // i128 out of -u64 range
-    assert!(to_vec(&(-(u64::MAX as i128) - 1)).is_err());
+    assert!(to_vec(&i128::MIN).is_err());
 }
 
 #[test]


### PR DESCRIPTION
The smallest possible CBOR integer value is -2^64. `u64::MAX` is (2^64) - 1. This means that we need to test for `-(u64::MAX + 1)`.

Related to #14 and #15.