### PR TITLE
Return deserialize_bytes() in CidDeserializer::deserialize_any

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -618,10 +618,8 @@ struct CidDeserializer<'a, R>(&'a mut Deserializer<R>);
 impl<'de, 'a, R: dec::Read<'de>> de::Deserializer<'de> for &'a mut CidDeserializer<'a, R> {
     type Error = DecodeError<R::Error>;
 
-    fn deserialize_any<V: de::Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
-        Err(de::Error::custom(
-            "Only bytes can be deserialized into a CID",
-        ))
+    fn deserialize_any<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_bytes(visitor)
     }
 
     #[inline]

--- a/tests/cid.rs
+++ b/tests/cid.rs
@@ -220,6 +220,55 @@ fn test_cid_in_kinded_enum_with_newtype() {
 }
 
 #[test]
+fn test_cid_in_tagged_enum() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    pub enum Externally {
+        Cid(Cid),
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    #[serde(tag = "type")]
+    pub enum Internally {
+        Cid { cid: Cid },
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    #[serde(untagged)]
+    pub enum Untagged {
+        Cid(Cid),
+    }
+
+    let cbor_cid = [
+        0xd8, 0x2a, 0x58, 0x25, 0x00, 0x01, 0x55, 0x12, 0x20, 0x2c, 0x26, 0xb4, 0x6b, 0x68, 0xff,
+        0xc6, 0x8f, 0xf9, 0x9b, 0x45, 0x3c, 0x1d, 0x30, 0x41, 0x34, 0x13, 0x42, 0x2d, 0x70, 0x64,
+        0x83, 0xbf, 0xa0, 0xf9, 0x8a, 0x5e, 0x88, 0x62, 0x66, 0xe7, 0xae,
+    ];
+
+    // {"Cid": cid}
+    let cbor_map1 = [vec![0xa1, 0x63, 0x43, 0x69, 0x64], Vec::from(cbor_cid)].concat();
+
+    // {"cid": cid, "type": "Cid"}
+    let cbor_map2 = [
+        vec![
+            0xa2, 0x64, 0x74, 0x79, 0x70, 0x65, 0x63, 0x43, 0x69, 0x64, 0x63, 0x63, 0x69, 0x64,
+        ],
+        Vec::from(cbor_cid),
+    ]
+    .concat();
+
+    let cid = Cid::try_from(&cbor_cid[5..]).unwrap();
+
+    let decoded: Externally = from_slice(&cbor_map1).unwrap();
+    assert_eq!(decoded, Externally::Cid(cid));
+
+    let decoded: Internally = from_slice(&cbor_map2).unwrap();
+    assert_eq!(decoded, Internally::Cid { cid });
+
+    let decoded: Untagged = from_slice(&cbor_cid).unwrap();
+    assert_eq!(decoded, Untagged::Cid(cid));
+}
+
+#[test]
 fn test_cid_empty_errors() {
     // Tag 42 with zero bytes
     let cbor_empty_cid = [0xd8, 0x2a, 0x40];


### PR DESCRIPTION
When deserializing data containing `cid` as an `enum`, there was no problem if it was [Externally tagged](https://serde.rs/enum-representations.html#externally-tagged), but an Error was returned when it was [Internally tagged](https://serde.rs/enum-representations.html#internally-tagged) or [Untagged](https://serde.rs/enum-representations.html#untagged).
This seems to be because the `serde` will call `deserialize_any` in the Internally tagged/Untagged case. That caused `CidDeserializer::deserialize_any` to return an Error when called.

In reality, however, `CidDeserializer` is only used from `Deserializer::deserialize_cid`. I thought that when this `CidDeserializer` is used, the input that should be processed is the bytes of the cid, and there should be no problem processing it with `deserialize_bytes`. Returning `self.deserialize_bytes(visitor)` does not affect the results of the existing tests.

It is possible that I am not understanding this well enough, but is there any reason why I should return an Error here?
