### PR TITLE
feat: upgrade rust-cid and use use ipld-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ edition = "2018"
 
 [dependencies]
 cbor4ii = { version = "0.2.14", default-features = false, features = ["use_alloc"] }
-cid = { version = "0.10.1", default-features = false, features = ["serde-codec"] }
+cid = { version = "0.11.0", default-features = false, features = ["serde-codec"] }
 scopeguard = "1.1.0"
 serde = { version = "1.0.164", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
+ipld-core = { version = "0.2.0", features = ["serde"] }
 serde_derive = { version = "1.0.164", default-features = false }
-libipld-core = { version = "0.16.0", default-features = false, features = ["serde-codec"] }
 serde_bytes = { version = "0.11.9", default-features = false, features = ["alloc"]}
 
 [features]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This crate started as a fork of [serde_cbor], thanks everyone involved there.
 
 [Serde]: https://github.com/serde-rs/serde
 [DAG-CBOR]: https://ipld.io/specs/codecs/dag-cbor/spec/
-[ipld-core]: https://github.com/vmx/ipld-core
+[ipld-core]: https://github.com/ipld/rust-ipld-core
 [cbor4ii]: https://github.com/quininer/cbor4ii
 [serde_cbor]: https://github.com/pyfisch/cbor
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Serde IPLD DAG-CBOR
 [![Crates.io](https://img.shields.io/crates/v/serde_ipld_dag_cbor.svg)](https://crates.io/crates/serde_ipld_dagcbor)
 [![Documentation](https://docs.rs/serde_ipld_dag_cbor/badge.svg)](https://docs.rs/serde_ipld_dag_cbor)
 
-This is a [Serde] implementation for [DAG-CBOR]. It can be use in conjunction with [libipld].
+This is a [Serde] implementation for [DAG-CBOR]. It can be use in conjunction with [ipld-core].
 
 The underlying library for CBOR encoding/decoding is [cbor4ii] and the Serde implementation is also heavily based on their code.
 
@@ -12,7 +12,7 @@ This crate started as a fork of [serde_cbor], thanks everyone involved there.
 
 [Serde]: https://github.com/serde-rs/serde
 [DAG-CBOR]: https://ipld.io/specs/codecs/dag-cbor/spec/
-[libipld]: https://github.com/ipld/libipld
+[ipld-core]: https://github.com/vmx/ipld-core
 [cbor4ii]: https://github.com/quininer/cbor4ii
 [serde_cbor]: https://github.com/pyfisch/cbor
 

--- a/examples/enums.rs
+++ b/examples/enums.rs
@@ -4,9 +4,10 @@
 use std::convert::{TryFrom, TryInto};
 
 use cid::Cid;
-use libipld_core::ipld::Ipld;
+use ipld_core::ipld::Ipld;
 use serde::{de, Deserialize};
 use serde_bytes::ByteBuf;
+use serde_derive::Deserialize;
 use serde_ipld_dagcbor::from_slice;
 
 /// The CID `bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy` encoded as CBOR

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //! ```
 //!
 //! There are a lot of options available to customize the format.
-//! To operate on untyped DAG-CBOR values have a look at the [`libipld_core::ipld::Ipld`] type.
+//! To operate on untyped DAG-CBOR values have a look at the [`ipld_core::ipld::Ipld`] type.
 //!
 //! # Type-based Serialization and Deserialization
 //! Serde provides a mechanism for low boilerplate serialization & deserialization of values to and
@@ -70,7 +70,7 @@
 //!
 //! ```rust
 //! use serde_ipld_dagcbor::from_slice;
-//! use libipld_core::ipld::Ipld;
+//! use ipld_core::ipld::Ipld;
 //!
 //! let slice = b"\x82\x01\xa1aaab";
 //! let value: Ipld = from_slice(slice).unwrap();

--- a/tests/cid.rs
+++ b/tests/cid.rs
@@ -3,10 +3,10 @@ use std::io::Cursor;
 use std::str::FromStr;
 
 use cid::Cid;
-use libipld_core::ipld::Ipld;
+use ipld_core::ipld::Ipld;
 use serde::de;
-use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
+use serde_derive::{Deserialize, Serialize};
 use serde_ipld_dagcbor::{from_reader, from_slice, to_vec};
 
 #[test]

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use libipld_core::ipld::Ipld;
+use ipld_core::ipld::Ipld;
 use serde_ipld_dagcbor::{de, to_vec, DecodeError};
 
 #[test]

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use serde_ipld_dagcbor::{from_slice, to_vec, DecodeError};
 

--- a/tests/ipld.rs
+++ b/tests/ipld.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
-use libipld_core::ipld::Ipld;
-use serde::{Deserialize, Serialize};
+use ipld_core::ipld::Ipld;
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 struct TupleStruct(String, i32, u64);
@@ -50,7 +50,7 @@ fn serde() {
         array,
     };
 
-    let ipld = libipld_core::serde::to_ipld(data.clone()).unwrap();
+    let ipld = ipld_core::serde::to_ipld(data.clone()).unwrap();
     println!("{:?}", ipld);
 
     let data_ser = serde_ipld_dagcbor::to_vec(&ipld).unwrap();
@@ -74,7 +74,7 @@ fn serde() {
 #[test]
 fn unit_struct_not_supported() {
     let unit_array = vec![UnitStruct, UnitStruct, UnitStruct];
-    let ipld = libipld_core::serde::to_ipld(unit_array);
+    let ipld = ipld_core::serde::to_ipld(unit_array);
     assert!(ipld.is_err());
 }
 

--- a/tests/std_types.rs
+++ b/tests/std_types.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use serde_ipld_dagcbor::{from_slice, to_vec};
 


### PR DESCRIPTION
Intead of relying on libipld-core, use ipld-core instead. This also enables the upgrade to rust-cid v0.11.