### PR TITLE
Support serde-transcode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0.164", default-features = false, features = ["alloc"] }
 [dev-dependencies]
 serde_derive = { version = "1.0.164", default-features = false }
 serde_bytes = { version = "0.11.9", default-features = false, features = ["alloc"]}
+serde-transcode = "1.1.1"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This PR is split into two commits:

---

feat: allow serializer to be used with serde-transcode

Prior to this change, the `Serializer` was private. With this change it's now
possible to use this library with `serde-transcode` [1].

The handling of the map key order needed to be changed. We were using `collect_map`
in order to make sure maps have the correct order. But that is only called when a
`BTreeMap` or `HashMap` is used [2]. `serde-transcode` calls `serialize_map`
directly. Therefore the logic to do the sorting was moved into the `SerializeMap`
implementation. This way it's used by all known cases.

[1]: https://crates.io/crates/serde-transcode
[2]: https://github.com/serde-rs/serde/blob/00c4b0cef80557c33fbcd75fcc70dc034720b4df/serde/src/ser/impls.rs#L430-L487

Closes https://github.com/ipld/serde_ipld_dagcbor/issues/26.

---


fix: make sure sequences are always bound

With the `Serializer` being public and being able to being used with
serde-transcode [1], we need to make sure that always valid DAG-CBOR
is generated, this means that sequences are always bound ones, where
the size is known beforehand. If the input is an unbound sequence,
then the data is buffered until the total size was determined.

[1]: https://crates.io/crates/serde-transcode