### PR TITLE
fix: introduce `codec` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,12 @@ serde_bytes = { version = "0.11.9", default-features = false, features = ["alloc
 serde-transcode = "1.1.1"
 
 [features]
-default = ["std"]
+default = ["codec", "std"]
 std = ["cbor4ii/use_std", "ipld-core/std", "serde/std", "serde_bytes/std"]
+# Enable the `Codec` trait implementation. It's a separate feature as it needs Rust >= 1.75.
+codec = ["ipld-core/codec"]
 # Prevent deserializing CIDs as bytes as much as possible.
 no-cid-as-bytes = []
+
+[patch.crates-io]
+ipld-core = { git = "https://github.com/ipld/rust-ipld-core", branch = "codec-feature-flag" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 cbor4ii = { version = "0.2.14", default-features = false, features = ["use_alloc"] }
-ipld-core = { version = "0.3.2", default-features = false, features = ["serde"] }
+ipld-core = { version = "0.4.0", default-features = false, features = ["serde"] }
 scopeguard = "1.1.0"
 serde = { version = "1.0.164", default-features = false, features = ["alloc"] }
 
@@ -32,6 +32,3 @@ std = ["cbor4ii/use_std", "ipld-core/std", "serde/std", "serde_bytes/std"]
 codec = ["ipld-core/codec"]
 # Prevent deserializing CIDs as bytes as much as possible.
 no-cid-as-bytes = []
-
-[patch.crates-io]
-ipld-core = { git = "https://github.com/ipld/rust-ipld-core", branch = "codec-feature-flag" }

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 Features
 --------
 
+### `codec`
+
+The `codec` feature is enabled by default, it provides the `Codec` trait, which enables encoding and decoding independent of the IPLD Codec. The minimum supported Rust version (MSRV) can significantly be reduced to 1.64 by disabling this feature.
+
+
 ### `no-cid-as-bytes`
 
 Sometimes it is desired that a CID is not accidentally deserialized into bytes. This can happen because the intermediate serde data model does not retain enough information to be able to differentiate between a bytes container and a CID container when there is a conflicting choice to be made, as in the case of some enum cases. The `no-cid-as-bytes` feature can be enabled in order to error at runtime in such cases.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ extern crate alloc;
 mod cbor4ii_nonpub;
 // The `Codec` implementation is only available if the `no-cid-as-bytes` feature is disabled, due
 // to the links being extracted with a Serde based approach.
-#[cfg(all(feature = "std", not(feature = "no-cid-as-bytes")))]
+#[cfg(all(feature = "std", not(feature = "no-cid-as-bytes"), feature = "codec"))]
 pub mod codec;
 pub mod de;
 pub mod error;


### PR DESCRIPTION
Implementing the `Codec` trait needs at least Rust version 1.75. This commit introduces a feature flag, so that lower versions of Rust can be supported, in case the `Codec` trait implementation is not needed.

---

I'll of course remove the patch versions, once there's a released version of `ipld-core`.