### PR TITLE
Derive common traits for `DagCborCodec`

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -12,6 +12,7 @@ use serde::{de::Deserialize, ser::Serialize};
 use crate::{de::Deserializer, error::CodecError};
 
 /// DAG-CBOR implementation of ipld-core's `Codec` trait.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct DagCborCodec;
 
 impl<T> Codec<T> for DagCborCodec


### PR DESCRIPTION
Hey folks 👋 

I'm upgrading some of my WIP IPLD libraries to `ipld-core`, and have found a few things that I think may be helpful upstream rather than just writing my own versions plus conversions.

This one is a small change to derive `Copy`, `Clone`, `Debug`, `PartialEq`, and `Eq`. Some of the tools I'm writing do automatic encoding/decoding into the `Ipld` data model, and so I need to be able to pass around the codec in a config struct. This is difficult in many places without at least `Copy` or `Clone`.

If this PR is accepted, I can do the same for `DagJsonCodec and `DagPbCodec`.

Thanks 😃🦀