### PR TITLE
Add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,167 @@
+{
+  "nodes": {
+    "command-utils": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1709702368,
+        "narHash": "sha256-1YOPubkJ5M6HigdfN0gn0AZ3kx6MHboG9UbWpYpk3gM=",
+        "owner": "expede",
+        "repo": "nix-command-utils",
+        "rev": "8f7179876383495b1f98311e53ebb41649ca270a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "expede",
+        "repo": "nix-command-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixos-unstable": {
+      "locked": {
+        "lastModified": 1713646843,
+        "narHash": "sha256-Klws8f3v0s6V1WbKp47x5tR5z3FsiZJg3cC3KHjKyZ8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2bdd06e1d8e8b370a486251727f6ee6b059ff055",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1709569716,
+        "narHash": "sha256-iOR44RU4jQ+YPGrn+uQeYAp7Xo7Z/+gT+wXJoGxxLTY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "617579a787259b9a6419492eaac670a5f7663917",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-23.11",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1713564160,
+        "narHash": "sha256-YguPZpiejgzLEcO36/SZULjJQ55iWcjAmf3lYiyV1Fo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bc194f70731cc5d2b046a6c1b3b15f170f05999c",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-23.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "command-utils": "command-utils",
+        "flake-utils": "flake-utils_2",
+        "nixos-unstable": "nixos-unstable",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1713579131,
+        "narHash": "sha256-j/lrqFNzm7SdlBlKX43kA2Wp0OaGVOUjQGnER9//4Ao=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "67e961704b80454f1ba6595b02e26afc9af4cdce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,166 @@
+{
+  description = "serde_ipld_dagcbor";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-23.11";
+    nixos-unstable.url = "nixpkgs/nixos-unstable-small";
+
+    command-utils.url = "github:expede/nix-command-utils";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+  };
+
+  outputs = {
+      self,
+      nixpkgs,
+      nixos-unstable,
+      command-utils,
+      flake-utils,
+      rust-overlay,
+  } @ inputs:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (import rust-overlay)
+          ];
+        };
+
+        unstable = import nixos-unstable {
+          inherit system;
+        };
+
+        rust-toolchain =
+          pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "cargo"
+              "clippy"
+              "rust-src"
+              "rust-std"
+              "rustfmt"
+            ];
+          };
+
+        nightly-rustfmt = pkgs.rust-bin.nightly.latest.rustfmt;
+
+        format-pkgs = [
+          pkgs.nixpkgs-fmt
+          pkgs.alejandra
+        ];
+
+        darwin-installs = [
+          pkgs.darwin.apple_sdk.frameworks.Security
+          pkgs.darwin.apple_sdk.frameworks.CoreFoundation
+          pkgs.darwin.apple_sdk.frameworks.Foundation
+        ];
+
+        cargo-installs = [
+          pkgs.cargo-expand
+          pkgs.cargo-outdated
+          pkgs.cargo-sort
+          pkgs.cargo-udeps
+          pkgs.cargo-watch
+        ];
+
+        cargo = "${pkgs.cargo}/bin/cargo";
+
+        cmd = command-utils.cmd.${system};
+
+        release = {
+          "release" = cmd "Build release for ${system}"
+            "${cargo} build --release";
+        };
+
+        build = {
+          "build" = cmd "Build for ${system}"
+            "${cargo} build";
+        };
+
+        lint = {
+          "lint" = cmd "Run Clippy"
+            "${cargo} clippy";
+
+          "lint:pedantic" = cmd "Run Clippy pedantically"
+            "${cargo} clippy -- -W clippy::pedantic";
+
+          "lint:fix" = cmd "Apply non-pendantic Clippy suggestions"
+            "${cargo} clippy --fix";
+        };
+
+        watch = {
+          "watch:build" = cmd "Rebuild host target on save"
+            "${cargo} watch --clear";
+
+          "watch:lint" = cmd "Lint on save"
+            "${cargo} watch --clear --exec clippy";
+
+          "watch:lint:pedantic" = cmd "Pedantic lint on save"
+            "${cargo} watch --clear --exec 'clippy -- -W clippy::pedantic'";
+
+          "watch:test" = cmd "Run all host tests on save"
+            "${cargo} watch --clear --exec test";
+        };
+
+        test = {
+          "tests" = cmd "Run Cargo tests for host target"
+            "${cargo} test";
+
+          "tests:docs" = cmd "Run Cargo doctests"
+            "${cargo} test --doc";
+        };
+
+        docs = {
+          "docs" = cmd "Refresh the docs"
+            "${cargo} doc";
+
+          "docs:open" = cmd "Open refreshed docs"
+            "${cargo} doc --open";
+        };
+
+        command_menu = command-utils.commands.${system}
+          (release // build // lint // watch // test // docs);
+
+      in rec {
+        devShells.default = pkgs.mkShell {
+          name = "serde_ipld_dagcbor";
+
+          nativeBuildInputs = [
+            rust-toolchain
+            self.packages.${system}.irust
+            (pkgs.hiPrio pkgs.rust-bin.nightly.latest.rustfmt)
+            command_menu
+          ]
+          ++ format-pkgs
+          ++ cargo-installs
+          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwin-installs;
+
+          shellHook = ''
+            unset SOURCE_DATE_EPOCH
+            menu    
+          '';
+        };
+
+        formatter = pkgs.alejandra;
+
+        packages.irust = pkgs.rustPlatform.buildRustPackage rec {
+          pname = "irust";
+          version = "1.71.19";
+          src = pkgs.fetchFromGitHub {
+            owner = "sigmaSd";
+            repo = "IRust";
+            rev = "irust@${version}";
+            sha256 = "sha256-R3EAovCI5xDCQ5R69nMeE6v0cGVcY00O3kV8qHf0akc=";
+          };
+
+          doCheck = false;
+          cargoSha256 = "sha256-2aVCNz/Lw7364B5dgGaloVPcQHm2E+b/BOxF6Qlc8Hs=";
+        };
+      }
+    );
+}


### PR DESCRIPTION
This PR is extremely optional, but I figured I'd contribute this while I had the hood up for #32 

In short: I added a `flake.nix` for any other [Nix](https://nixos.org) users show up. This doesn't impact non-Nix users in any way, but gives anyone with Nix installed an instant, correctly configured dev environment.