### PR TITLE
feat!: remove strict length check on tuple deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ edition = "2018"
 
 [dependencies]
 cbor4ii = { version = "0.2.14", default-features = false, features = ["use_alloc"] }
-const-hex = "1.14.0"
 ipld-core = { version = "0.4.2", default-features = false, features = ["serde"] }
 scopeguard = "1.1.0"
 serde = { version = "1.0.164", default-features = false, features = ["alloc"] }
-serde_tuple = "1.1.0"
 
 [dev-dependencies]
 serde_derive = { version = "1.0.164", default-features = false }
 serde_bytes = { version = "0.11.9", default-features = false, features = ["alloc"]}
 serde-transcode = "1.1.1"
+const-hex = "1.14.0"
+serde_tuple = "1.1.0"
 
 [features]
 default = ["codec", "std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ edition = "2018"
 [dependencies]
 cbor4ii = { version = "0.2.14", default-features = false, features = ["use_alloc"] }
 const-hex = "1.14.0"
-ipld-core = { path = "../rust-ipld-core", default-features = false, features = ["serde"] }
-# ipld-core = { version = "0.4.0", default-features = false, features = ["serde"] }
+ipld-core = { version = "0.4.2", default-features = false, features = ["serde"] }
 scopeguard = "1.1.0"
 serde = { version = "1.0.164", default-features = false, features = ["alloc"] }
 serde_tuple = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,12 @@ edition = "2018"
 
 [dependencies]
 cbor4ii = { version = "0.2.14", default-features = false, features = ["use_alloc"] }
-ipld-core = { version = "0.4.0", default-features = false, features = ["serde"] }
+const-hex = "1.14.0"
+ipld-core = { path = "../rust-ipld-core", default-features = false, features = ["serde"] }
+# ipld-core = { version = "0.4.0", default-features = false, features = ["serde"] }
 scopeguard = "1.1.0"
 serde = { version = "1.0.164", default-features = false, features = ["alloc"] }
+serde_tuple = "1.1.0"
 
 [dev-dependencies]
 serde_derive = { version = "1.0.164", default-features = false }

--- a/examples/enums.rs
+++ b/examples/enums.rs
@@ -6,7 +6,6 @@ use std::convert::{TryFrom, TryInto};
 use ipld_core::{cid::Cid, ipld::Ipld};
 use serde::{de, Deserialize};
 use serde_bytes::ByteBuf;
-use serde_derive::Deserialize;
 use serde_ipld_dagcbor::from_slice;
 
 /// The CID `bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy` encoded as CBOR

--- a/src/de.rs
+++ b/src/de.rs
@@ -154,14 +154,14 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
     {
         let mut de = self.try_step()?;
         let mut seq = Accessor::array(&mut de)?;
-        let expect = seq.len;
+        let value = seq.len;
         let res = visitor.visit_seq(&mut seq)?;
         match seq.len {
             0 => Ok(res),
             remaining => Err(DecodeError::RequireLength {
                 name,
-                expect,
-                value: expect - remaining,
+                expect: value - remaining,
+                value,
             }),
         }
     }
@@ -176,14 +176,14 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
     {
         let mut de = self.try_step()?;
         let mut map = Accessor::map(&mut de)?;
-        let expect = map.len;
+        let value = map.len;
         let res = visitor.visit_map(&mut map)?;
         match map.len {
             0 => Ok(res),
             remaining => Err(DecodeError::RequireLength {
                 name,
-                expect,
-                value: expect - remaining,
+                expect: value - remaining,
+                value,
             }),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,7 +67,7 @@ impl<E: fmt::Debug> From<cbor4ii::EncodeError<E>> for EncodeError<E> {
 }
 
 /// A decoding error.
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum DecodeError<E> {
     /// Custom error message.
     Msg(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -101,7 +101,8 @@ pub enum DecodeError<E> {
         /// Type name (e.g. "bytes", "str").
         name: &'static str,
     },
-    /// Length wasn't large enough.
+    /// Length wasn't large enough. This error comes after attempting to consume the entirety of a
+    /// item with a known length and failing to do so.
     RequireLength {
         /// Type name.
         name: &'static str,

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,7 +67,7 @@ impl<E: fmt::Debug> From<cbor4ii::EncodeError<E>> for EncodeError<E> {
 }
 
 /// A decoding error.
-#[derive(Debug)]
+#[derive(Debug,PartialEq)]
 pub enum DecodeError<E> {
     /// Custom error message.
     Msg(String),

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -386,7 +386,9 @@ fn test_default_values() {
         // [202,"nup",false] has too many elements so it errors with RequireLength
         TestCase {
             hex: "8318ca636e7570f4",
-            expected: Expected::Err(|err| matches!(err, DecodeError::TrailingData)),
+            expected: Expected::Err(
+                |err| matches!(err, DecodeError::RequireLength{ name, expect, value} if *name == "TupleWithDefaultsStruct" && *expect == 2 && *value == 3),
+            ),
         },
     ];
 
@@ -418,10 +420,9 @@ fn test_default_values() {
         // [505,[202,"nup",false],606] has too many elements on inner so it errors with RequireLength
         TestCase {
             hex: "831901f98318ca636e7570f419025e",
-            expected: Expected::Err(|err| {
-                // false is 0xf4, out of place, and we expect to roll into an int (with major 0)
-                matches!(err, DecodeError::Mismatch { expect_major, byte } if *expect_major == 0 && *byte == 0xf4)
-            }),
+            expected: Expected::Err(
+                |err| matches!(err, DecodeError::RequireLength{ name, expect, value} if *name == "TupleWithDefaultsStruct" && *expect == 2 && *value == 3),
+            ),
         },
         // [505,[]]
         TestCase {

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -48,19 +48,19 @@ fn test_f32() {
 
 #[test]
 fn test_infinity() {
-    let vec = to_vec(&::std::f64::INFINITY);
+    let vec = to_vec(&f64::INFINITY);
     assert!(vec.is_err(), "Only finite numbers are supported.");
 }
 
 #[test]
 fn test_neg_infinity() {
-    let vec = to_vec(&::std::f64::NEG_INFINITY);
+    let vec = to_vec(&f64::NEG_INFINITY);
     assert!(vec.is_err(), "Only finite numbers are supported.");
 }
 
 #[test]
 fn test_nan() {
-    let vec = to_vec(&::std::f32::NAN);
+    let vec = to_vec(&f32::NAN);
     assert!(vec.is_err(), "Only finite numbers are supported.");
 }
 
@@ -79,7 +79,7 @@ fn test_integer() {
     let vec = to_vec(&-23567997).unwrap();
     assert_eq!(vec, b"\x3a\x01\x67\x9e\x7c");
     // u64
-    let vec = to_vec(&::std::u64::MAX).unwrap();
+    let vec = to_vec(&u64::MAX).unwrap();
     assert_eq!(vec, b"\x1b\xff\xff\xff\xff\xff\xff\xff\xff");
     // u128 within u64 range
     let vec = to_vec(&(u64::MAX as u128)).unwrap();


### PR DESCRIPTION
Depends on: https://github.com/ipld/rust-ipld-core/pull/24

This should be handled by #[serde(deny_unknown_fields)] so it can also be used non-strict (for custom visitors/deserializers). Unfortunately this isn't supported upstream in serde yet, so we should work on that.