### PR TITLE
feat: add support for stream deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ serde_bytes = { version = "0.11.9", default-features = false, features = ["alloc
 serde-transcode = "1.1.1"
 const-hex = "1.14.0"
 serde_tuple = "1.1.0"
+# We need the RC feature to test a trait edge-case.
+serde = { version = "*", default-features = false, features = ["rc"] }
 
 [features]
 default = ["codec", "std"]

--- a/src/de.rs
+++ b/src/de.rs
@@ -558,7 +558,7 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
 /// An iterator over all the CBOR values in the iterator.
 pub struct StreamDeserializer<'de, R, T> {
     de: Deserializer<R>,
-    output: PhantomData<T>,
+    output: PhantomData<fn() -> T>,
     lifetime: PhantomData<&'de ()>,
 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -562,11 +562,7 @@ pub struct StreamDeserializer<'de, R, T> {
     lifetime: PhantomData<&'de ()>,
 }
 
-impl<'de, R, T> StreamDeserializer<'de, R, T>
-where
-    R: dec::Read<'de>,
-    T: de::Deserialize<'de>,
-{
+impl<R, T> StreamDeserializer<'_, R, T> {
     /// Create a new streaming deserializer.
     pub fn new(de: Deserializer<R>) -> Self {
         Self {

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -283,6 +283,24 @@ fn test_stream_deserializer() {
 
 #[cfg(feature = "std")]
 #[test]
+fn test_stream_deserializer_marker_traits() {
+    use std::rc::Rc;
+
+    fn is_send<T: Send>(_: &T) {}
+
+    let v: &[u8] = &[
+        0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72, 0x63, 0x62, 0x61, 0x7A,
+    ];
+    let reader = std::io::Cursor::new(v);
+    let reader = cbor4ii::core::utils::IoReader::new(reader);
+    let mut i = de::Deserializer::from_reader(reader).into_iter();
+    is_send(&i);
+    let value_1: Rc<String> = i.next().unwrap().unwrap();
+    assert_eq!(value_1.as_str(), "foobar");
+}
+
+#[cfg(feature = "std")]
+#[test]
 fn test_stream_deserializer_trailing_data() {
     // one byte missing on the end
     let v: &[u8] = &[0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72, 0x63, 0x62, 0x61];

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -253,6 +253,19 @@ fn test_object_determinism_roundtrip() {
     }
 }
 
+#[cfg(feature = "std")]
+#[test]
+fn test_from_reader_once() {
+    let v: &[u8] = &[
+        0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72, 0x63, 0x62, 0x61, 0x7A,
+    ];
+    let (value_1, v): (String, _) = de::from_reader_once(v).unwrap();
+    assert_eq!(value_1, "foobar");
+    let (value_2, v): (String, _) = de::from_reader_once(v).unwrap();
+    assert_eq!(value_2, "baz");
+    assert!(v.is_empty());
+}
+
 #[test]
 fn crash() {
     let file = include_bytes!("crash.cbor");

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -259,11 +259,12 @@ fn test_from_reader_once() {
     let v: &[u8] = &[
         0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72, 0x63, 0x62, 0x61, 0x7A,
     ];
-    let (value_1, v): (String, _) = de::from_reader_once(v).unwrap();
+    let mut reader = std::io::Cursor::new(v);
+    let value_1: String = de::from_reader_once(&mut reader).unwrap();
     assert_eq!(value_1, "foobar");
-    let (value_2, v): (String, _) = de::from_reader_once(v).unwrap();
+    let value_2: String = de::from_reader_once(&mut reader).unwrap();
     assert_eq!(value_2, "baz");
-    assert!(v.is_empty());
+    assert_eq!(v.len(), reader.position() as usize);
 }
 
 #[test]

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -255,6 +255,18 @@ fn test_object_determinism_roundtrip() {
 
 #[cfg(feature = "std")]
 #[test]
+fn test_from_reader_once() {
+    let v: &[u8] = &[0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72, 0x0a];
+    let mut reader = std::io::Cursor::new(v);
+    let value_1: String = de::from_reader_once(&mut reader).unwrap();
+    assert_eq!(value_1, "foobar");
+    let value_2: i32 = de::from_reader_once(&mut reader).unwrap();
+    assert_eq!(value_2, 10);
+    assert_eq!(v.len(), reader.position() as usize);
+}
+
+#[cfg(feature = "std")]
+#[test]
 fn test_stream_deserializer() {
     let v: &[u8] = &[
         0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72, 0x63, 0x62, 0x61, 0x7A,


### PR DESCRIPTION
The existing de::from_reader will fail if there is trailing data at the end of the reader. This leads to patterns such as passing a cursor in as the reader, allowing it to fail with `DecodeError::TrailingData`, checking how much data was used before the error, creating a slice containing only the portion before the trailing data, and reparsing[1].

This new function allows the user to decode a concatenated stream of values without having to double-parse to determine the length.

1. https://docs.rs/crate/bluesky-firehose-stream/0.1.1/source/src/frame.rs#84