### PR TITLE
feat: make the DAG-CBOR multicodec code public

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -9,7 +9,7 @@ use ipld_core::{
 };
 use serde::{de::Deserialize, ser::Serialize};
 
-use crate::{de::Deserializer, error::CodecError};
+use crate::{de::Deserializer, error::CodecError, DAG_CBOR_CODE};
 
 /// DAG-CBOR implementation of ipld-core's `Codec` trait.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -19,7 +19,7 @@ impl<T> Codec<T> for DagCborCodec
 where
     T: for<'a> Deserialize<'a> + Serialize,
 {
-    const CODE: u64 = 0x71;
+    const CODE: u64 = DAG_CBOR_CODE;
     type Error = CodecError;
 
     fn decode<R: BufRead>(reader: R) -> Result<T, Self::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,5 +141,8 @@ pub use crate::ser::to_vec;
 #[doc(inline)]
 pub use crate::ser::to_writer;
 
+/// The multicodec code for DAG-CBOR.
+pub const DAG_CBOR_CODE: u64 = 0x71;
+
 /// The CBOR tag that is used for CIDs.
 const CBOR_TAGS_CID: u64 = 42;


### PR DESCRIPTION
There is no easy way to get the DAG-CBOR multicodec code from this library. This commits adds a public constant called `DAG_CBOR_CODE`.