### PR TITLE
chore!: bump `cbor4ii` to `1.2.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["encoding"]
 edition = "2018"
 
 [dependencies]
-cbor4ii = { version = "0.2.14", default-features = false, features = ["use_alloc"] }
+cbor4ii = { version = "1.2.2", default-features = false, features = ["use_alloc"] }
 ipld-core = { version = "0.4.2", default-features = false, features = ["serde"] }
 scopeguard = { version = "1.1.0", default-features = false }
 serde = { version = "1.0.164", default-features = false, features = ["alloc"] }

--- a/src/cbor4ii_nonpub.rs
+++ b/src/cbor4ii_nonpub.rs
@@ -1,41 +1,30 @@
-//! This module contains code that was just copied from cbor4ii.
-//!
-//! Some things needed for the Serde implementation are not public in the cbor4ii crate. Those are
-//! copied into this file.
+//! Re-implementations of cbor4ii's `pub(crate)` `peek_one`/`pull_one` so we can produce our own
+//! `DecodeError::Eof` instead of going through the upstream constructor.
 
 use cbor4ii::core::dec;
+use cbor4ii::core::error::Len;
 
 use crate::error::DecodeError;
 
-// Copy from cbor4ii/core.rs.
-#[allow(dead_code)]
-pub(crate) mod marker {
-    pub const START: u8 = 0x1f;
-    pub const FALSE: u8 = 0xf4; // simple(20)
-    pub const TRUE: u8 = 0xf5; // simple(21)
-    pub const NULL: u8 = 0xf6; // simple(22)
-    pub const UNDEFINED: u8 = 0xf7; // simple(23)
-    pub const F16: u8 = 0xf9;
-    pub const F32: u8 = 0xfa;
-    pub const F64: u8 = 0xfb;
-    pub const BREAK: u8 = 0xff;
-}
-
-// Copy from cbor4ii/core/dec.rs.
 #[inline]
-pub(crate) fn peek_one<'a, R: dec::Read<'a>>(reader: &mut R) -> Result<u8, DecodeError<R::Error>> {
-    let buf = match reader.fill(1)? {
-        dec::Reference::Long(buf) => buf,
-        dec::Reference::Short(buf) => buf,
-    };
-    let byte = buf.first().copied().ok_or(DecodeError::Eof)?;
+pub(crate) fn peek_one<'a, R: dec::Read<'a>>(
+    name: &'static str,
+    reader: &mut R,
+) -> Result<u8, DecodeError<R::Error>> {
+    let buf = reader.fill(1)?;
+    let byte = buf.as_ref().first().copied().ok_or(DecodeError::Eof {
+        name,
+        expect: Len::Small(1),
+    })?;
     Ok(byte)
 }
 
-// Copy from cbor4ii/core/dec.rs.
 #[inline]
-pub(crate) fn pull_one<'a, R: dec::Read<'a>>(reader: &mut R) -> Result<u8, DecodeError<R::Error>> {
-    let byte = peek_one(reader)?;
+pub(crate) fn pull_one<'a, R: dec::Read<'a>>(
+    name: &'static str,
+    reader: &mut R,
+) -> Result<u8, DecodeError<R::Error>> {
+    let byte = peek_one(name, reader)?;
     reader.advance(1);
     Ok(byte)
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -8,11 +8,11 @@ use serde::Deserialize;
 use std::borrow::Cow;
 
 use cbor4ii::core::dec::{self, Decode};
-use cbor4ii::core::{major, types, utils::SliceReader};
+use cbor4ii::core::{major, marker, types, utils::SliceReader};
 use ipld_core::cid::serde::CID_SERDE_PRIVATE_IDENTIFIER;
 use serde::de::{self, Visitor};
 
-use crate::cbor4ii_nonpub::{marker, peek_one, pull_one};
+use crate::cbor4ii_nonpub::{peek_one, pull_one};
 use crate::error::DecodeError;
 use crate::CBOR_TAGS_CID;
 #[cfg(feature = "std")]
@@ -199,7 +199,7 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
         if self.reader.step_in() {
             Ok(scopeguard::guard(self, |de| de.reader.step_out()))
         } else {
-            Err(DecodeError::DepthLimit)
+            Err(DecodeError::DepthOverflow { name: "value" })
         }
     }
 
@@ -208,13 +208,13 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        let tag = dec::TagStart::decode(&mut self.reader)?;
+        let tag = types::Tag::tag(&mut self.reader)?;
 
-        match tag.0 {
+        match tag {
             CBOR_TAGS_CID => visitor.visit_newtype_struct(&mut CidDeserializer(self)),
-            _ => Err(DecodeError::TypeMismatch {
+            _ => Err(DecodeError::Mismatch {
                 name: "CBOR tag",
-                byte: tag.0 as u8,
+                found: tag as u8,
             }),
         }
     }
@@ -222,9 +222,9 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
     /// This method should be called after a value has been deserialized to ensure there is no
     /// trailing data in the input source.
     pub fn end(&mut self) -> Result<(), DecodeError<R::Error>> {
-        match peek_one(&mut self.reader) {
+        match peek_one("value", &mut self.reader) {
             Ok(_) => Err(DecodeError::TrailingData),
-            Err(DecodeError::Eof) => Ok(()),
+            Err(DecodeError::Eof { .. }) => Ok(()),
             Err(error) => Err(error),
         }
     }
@@ -243,7 +243,7 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
         let res = visitor.visit_seq(&mut seq)?;
         match seq.len {
             0 => Ok(res),
-            remaining => Err(DecodeError::RequireLength {
+            remaining => Err(DecodeError::LengthMismatch {
                 name,
                 expect: value - remaining,
                 value,
@@ -265,7 +265,7 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
         let res = visitor.visit_map(&mut map)?;
         match map.len {
             0 => Ok(res),
-            remaining => Err(DecodeError::RequireLength {
+            remaining => Err(DecodeError::LengthMismatch {
                 name,
                 expect: value - remaining,
                 value,
@@ -301,7 +301,7 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
         let mut de = self.try_step()?;
         let de = &mut *de;
 
-        let byte = peek_one(&mut de.reader)?;
+        let byte = peek_one("value", &mut de.reader)?;
         if is_indefinite(byte) {
             return Err(DecodeError::IndefiniteSize);
         }
@@ -337,9 +337,15 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
                 }
                 marker::F32 => de.deserialize_f32(visitor),
                 marker::F64 => de.deserialize_f64(visitor),
-                _ => Err(DecodeError::Unsupported { byte }),
+                _ => Err(DecodeError::Unsupported {
+                    name: "value",
+                    found: byte,
+                }),
             },
-            _ => Err(DecodeError::Unsupported { byte }),
+            _ => Err(DecodeError::Unsupported {
+                name: "value",
+                found: byte,
+            }),
         }
     }
 
@@ -372,7 +378,7 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
         // We also accept f32 encoding, although a strict DAG-CBOR
         // implementation should reject it (please don't write new data
         // with f32 encoding).
-        let byte = peek_one(&mut self.reader)?;
+        let byte = peek_one("f32", &mut self.reader)?;
         match byte {
             marker::F32 => {
                 // Note: f32 encoding is not valid in strict DAG-CBOR.
@@ -403,7 +409,10 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
 
                 visitor.visit_f32(f32_value)
             }
-            _ => Err(DecodeError::TypeMismatch { name: "f32", byte }),
+            _ => Err(DecodeError::Mismatch {
+                name: "f32",
+                found: byte,
+            }),
         }
     }
 
@@ -461,7 +470,7 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        let byte = peek_one(&mut self.reader)?;
+        let byte = peek_one("option", &mut self.reader)?;
         if byte != marker::NULL {
             let mut de = self.try_step()?;
             visitor.visit_some(&mut **de)
@@ -476,11 +485,14 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        let byte = pull_one(&mut self.reader)?;
+        let byte = pull_one("unit", &mut self.reader)?;
         if byte == marker::NULL {
             visitor.visit_unit()
         } else {
-            Err(DecodeError::TypeMismatch { name: "unit", byte })
+            Err(DecodeError::Mismatch {
+                name: "unit",
+                found: byte,
+            })
         }
     }
 
@@ -647,8 +659,8 @@ struct Accessor<'a, R> {
 impl<'de, 'a, R: dec::Read<'de>> Accessor<'a, R> {
     #[inline]
     fn array(de: &'a mut Deserializer<R>) -> Result<Accessor<'a, R>, DecodeError<R::Error>> {
-        let array_start = dec::ArrayStart::decode(&mut de.reader)?;
-        array_start.0.map_or_else(
+        let len = types::Array::len(&mut de.reader)?;
+        len.map_or_else(
             || Err(DecodeError::IndefiniteSize),
             move |len| Ok(Accessor { de, len }),
         )
@@ -656,8 +668,8 @@ impl<'de, 'a, R: dec::Read<'de>> Accessor<'a, R> {
 
     #[inline]
     fn map(de: &'a mut Deserializer<R>) -> Result<Accessor<'a, R>, DecodeError<R::Error>> {
-        let map_start = dec::MapStart::decode(&mut de.reader)?;
-        map_start.0.map_or_else(
+        let len = types::Map::len(&mut de.reader)?;
+        len.map_or_else(
             || Err(DecodeError::IndefiniteSize),
             move |len| Ok(Accessor { de, len }),
         )
@@ -728,7 +740,7 @@ impl<'de, 'a, R: dec::Read<'de>> EnumAccessor<'a, R> {
     pub fn enum_(
         de: &'a mut Deserializer<R>,
     ) -> Result<EnumAccessor<'a, R>, DecodeError<R::Error>> {
-        let byte = peek_one(&mut de.reader)?;
+        let byte = peek_one("enum", &mut de.reader)?;
         match dec::if_major(byte) {
             // string
             major::STRING => Ok(EnumAccessor { de }),
@@ -737,7 +749,10 @@ impl<'de, 'a, R: dec::Read<'de>> EnumAccessor<'a, R> {
                 de.reader.advance(1);
                 Ok(EnumAccessor { de })
             }
-            _ => Err(DecodeError::TypeMismatch { name: "enum", byte }),
+            _ => Err(DecodeError::Mismatch {
+                name: "enum",
+                found: byte,
+            }),
         }
     }
 }
@@ -829,7 +844,7 @@ impl<'de, 'a, R: dec::Read<'de>> de::Deserializer<'de> for &'a mut CidDeserializ
 
     #[inline]
     fn deserialize_bytes<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        let byte = peek_one(&mut self.0.reader)?;
+        let byte = peek_one("cid", &mut self.0.reader)?;
         match dec::if_major(byte) {
             major::BYTES => {
                 // CBOR encoded CIDs have a zero byte prefix we have to remove.
@@ -851,7 +866,10 @@ impl<'de, 'a, R: dec::Read<'de>> de::Deserializer<'de> for &'a mut CidDeserializ
                     }
                 }
             }
-            _ => Err(DecodeError::Unsupported { byte }),
+            _ => Err(DecodeError::Unsupported {
+                name: "cid",
+                found: byte,
+            }),
         }
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,6 +1,7 @@
 //! Deserialization.
 #[cfg(not(feature = "std"))]
 use alloc::borrow::Cow;
+use cbor4ii::core::error;
 use core::convert::{Infallible, TryFrom};
 use core::marker::PhantomData;
 use serde::Deserialize;
@@ -194,12 +195,13 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
     #[inline]
     fn try_step<'a>(
         &'a mut self,
+        name: error::StaticStr,
     ) -> Result<scopeguard::ScopeGuard<&'a mut Self, fn(&'a mut Self) -> ()>, DecodeError<R::Error>>
     {
         if self.reader.step_in() {
             Ok(scopeguard::guard(self, |de| de.reader.step_out()))
         } else {
-            Err(DecodeError::DepthOverflow { name: "value" })
+            Err(DecodeError::DepthOverflow { name })
         }
     }
 
@@ -222,7 +224,7 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
     /// This method should be called after a value has been deserialized to ensure there is no
     /// trailing data in the input source.
     pub fn end(&mut self) -> Result<(), DecodeError<R::Error>> {
-        match peek_one("value", &mut self.reader) {
+        match peek_one("end", &mut self.reader) {
             Ok(_) => Err(DecodeError::TrailingData),
             Err(DecodeError::Eof { .. }) => Ok(()),
             Err(error) => Err(error),
@@ -237,7 +239,7 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        let mut de = self.try_step()?;
+        let mut de = self.try_step(&"seq")?;
         let mut seq = Accessor::array(&mut de)?;
         let value = seq.len;
         let res = visitor.visit_seq(&mut seq)?;
@@ -259,7 +261,7 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        let mut de = self.try_step()?;
+        let mut de = self.try_step(&"map")?;
         let mut map = Accessor::map(&mut de)?;
         let value = map.len;
         let res = visitor.visit_map(&mut map)?;
@@ -298,10 +300,11 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        let mut de = self.try_step()?;
+        let name = &"any";
+        let mut de = self.try_step(name)?;
         let de = &mut *de;
 
-        let byte = peek_one("value", &mut de.reader)?;
+        let byte = peek_one(name, &mut de.reader)?;
         if is_indefinite(byte) {
             return Err(DecodeError::IndefiniteSize);
         }
@@ -338,12 +341,12 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
                 marker::F32 => de.deserialize_f32(visitor),
                 marker::F64 => de.deserialize_f64(visitor),
                 _ => Err(DecodeError::Unsupported {
-                    name: "value",
+                    name: "any",
                     found: byte,
                 }),
             },
             _ => Err(DecodeError::Unsupported {
-                name: "value",
+                name: "any",
                 found: byte,
             }),
         }
@@ -470,9 +473,10 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        let byte = peek_one("option", &mut self.reader)?;
+        let name = &"option";
+        let byte = peek_one(name, &mut self.reader)?;
         if byte != marker::NULL {
-            let mut de = self.try_step()?;
+            let mut de = self.try_step(name)?;
             visitor.visit_some(&mut **de)
         } else {
             self.reader.advance(1);
@@ -584,7 +588,7 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        let mut de = self.try_step()?;
+        let mut de = self.try_step(&"enum")?;
         let accessor = EnumAccessor::enum_(&mut de)?;
         visitor.visit_enum(accessor)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,8 +4,9 @@ use alloc::{
     collections::TryReserveError,
     string::{String, ToString},
 };
-use core::{convert::Infallible, fmt, num::TryFromIntError};
+use core::{convert::Infallible, fmt};
 
+pub use cbor4ii::core::error::{ArithmeticOverflow, Len};
 use serde::{de, ser};
 
 /// An encoding error.
@@ -56,70 +57,95 @@ impl<E: fmt::Debug> fmt::Display for EncodeError<E> {
     }
 }
 
-impl<E: fmt::Debug> From<cbor4ii::EncodeError<E>> for EncodeError<E> {
-    fn from(err: cbor4ii::EncodeError<E>) -> EncodeError<E> {
+impl<E: fmt::Debug> From<cbor4ii::core::error::EncodeError<E>> for EncodeError<E> {
+    fn from(err: cbor4ii::core::error::EncodeError<E>) -> EncodeError<E> {
         match err {
-            cbor4ii::EncodeError::Write(e) => EncodeError::Write(e),
-            // Needed as `cbor4ii::EncodeError` is markes as non_exhaustive
+            cbor4ii::core::error::EncodeError::Write(e) => EncodeError::Write(e),
+            // Future-proof against new upstream variants without an SDK bump; loses structured info
+            // but preserves the Display string.
             _ => EncodeError::Msg(err.to_string()),
         }
     }
 }
 
 /// A decoding error.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum DecodeError<E> {
     /// Custom error message.
     Msg(String),
     /// IO error.
     Read(E),
     /// End of file.
-    Eof,
-    /// Unexpected byte.
-    Mismatch {
-        /// Expected CBOR major type.
-        expect_major: u8,
-        /// Unexpected byte.
-        byte: u8,
-    },
-    /// Unexpected type.
-    TypeMismatch {
+    Eof {
         /// Type name.
         name: &'static str,
-        /// Type byte.
-        byte: u8,
+        /// Expected length.
+        expect: Len,
     },
-    /// Too large integer.
-    CastOverflow(TryFromIntError),
-    /// Overflowing 128-bit integers.
-    Overflow {
-        /// Type of integer.
+    /// Unexpected byte.
+    Mismatch {
+        /// Type name.
         name: &'static str,
+        /// Unexpected byte.
+        found: u8,
     },
-    /// Decoding bytes/strings might require a borrow.
-    RequireBorrowed {
-        /// Type name (e.g. "bytes", "str").
+    /// Unsupported byte.
+    Unsupported {
+        /// Type name.
         name: &'static str,
+        /// Unsupported byte.
+        found: u8,
     },
-    /// Length wasn't large enough. This error comes after attempting to consume the entirety of a
-    /// item with a known length and failing to do so.
+    /// Length wasn't large enough.
     RequireLength {
         /// Type name.
         name: &'static str,
-        /// Required length.
-        expect: usize,
-        /// Given length.
-        value: usize,
+        /// Available length.
+        found: Len,
+    },
+    /// Required a borrow.
+    RequireBorrowed {
+        /// Type name.
+        name: &'static str,
     },
     /// Invalid UTF-8.
-    InvalidUtf8(core::str::Utf8Error),
-    /// Unsupported byte.
-    Unsupported {
-        /// Unsupported bute.
-        byte: u8,
+    RequireUtf8 {
+        /// Type name.
+        name: &'static str,
+    },
+    /// Length overflow.
+    LengthOverflow {
+        /// Type name.
+        name: &'static str,
+        /// Encoded length.
+        found: Len,
+    },
+    /// Cast overflow.
+    CastOverflow {
+        /// Type name.
+        name: &'static str,
+    },
+    /// Arithmetic overflow.
+    ArithmeticOverflow {
+        /// Type name.
+        name: &'static str,
+        /// Direction of the overflow.
+        ty: ArithmeticOverflow,
     },
     /// Recursion limit reached.
-    DepthLimit,
+    DepthOverflow {
+        /// Type name.
+        name: &'static str,
+    },
+    /// CBOR array/map length didn't match what serde expected.
+    LengthMismatch {
+        /// Type name.
+        name: &'static str,
+        /// Expected length.
+        expect: usize,
+        /// Actual length.
+        value: usize,
+    },
     /// Trailing data.
     TrailingData,
     /// Indefinite sized item was encountered.
@@ -150,7 +176,6 @@ impl<E: fmt::Debug> de::Error for DecodeError<E> {
 impl<E: std::error::Error + 'static> std::error::Error for DecodeError<E> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            DecodeError::Msg(_) => None,
             DecodeError::Read(err) => Some(err),
             _ => None,
         }
@@ -166,33 +191,29 @@ impl<E: fmt::Debug> fmt::Display for DecodeError<E> {
     }
 }
 
-impl<E: fmt::Debug> From<cbor4ii::DecodeError<E>> for DecodeError<E> {
-    fn from(err: cbor4ii::DecodeError<E>) -> DecodeError<E> {
+impl<E: fmt::Debug> From<cbor4ii::core::error::DecodeError<E>> for DecodeError<E> {
+    fn from(err: cbor4ii::core::error::DecodeError<E>) -> DecodeError<E> {
+        use cbor4ii::core::error::DecodeError as Cbor4iiError;
         match err {
-            cbor4ii::DecodeError::Read(read) => DecodeError::Read(read),
-            cbor4ii::DecodeError::Eof => DecodeError::Eof,
-            cbor4ii::DecodeError::Mismatch { expect_major, byte } => {
-                DecodeError::Mismatch { expect_major, byte }
+            Cbor4iiError::Read(read) => DecodeError::Read(read),
+            Cbor4iiError::Eof { name, expect } => DecodeError::Eof { name, expect },
+            Cbor4iiError::Mismatch { name, found } => DecodeError::Mismatch { name, found },
+            Cbor4iiError::Unsupported { name, found } => DecodeError::Unsupported { name, found },
+            Cbor4iiError::RequireLength { name, found } => {
+                DecodeError::RequireLength { name, found }
             }
-            cbor4ii::DecodeError::TypeMismatch { name, byte } => {
-                DecodeError::TypeMismatch { name, byte }
+            Cbor4iiError::RequireBorrowed { name } => DecodeError::RequireBorrowed { name },
+            Cbor4iiError::RequireUtf8 { name } => DecodeError::RequireUtf8 { name },
+            Cbor4iiError::LengthOverflow { name, found } => {
+                DecodeError::LengthOverflow { name, found }
             }
-            cbor4ii::DecodeError::CastOverflow(overflow) => DecodeError::CastOverflow(overflow),
-            cbor4ii::DecodeError::Overflow { name } => DecodeError::Overflow { name },
-            cbor4ii::DecodeError::RequireBorrowed { name } => DecodeError::RequireBorrowed { name },
-            cbor4ii::DecodeError::RequireLength {
-                name,
-                expect,
-                value,
-            } => DecodeError::RequireLength {
-                name,
-                expect,
-                value,
-            },
-            cbor4ii::DecodeError::InvalidUtf8(invalid) => DecodeError::InvalidUtf8(invalid),
-            cbor4ii::DecodeError::Unsupported { byte } => DecodeError::Unsupported { byte },
-            cbor4ii::DecodeError::DepthLimit => DecodeError::DepthLimit,
-            // Needed as `cbor4ii::EncodeError` is markes as non_exhaustive
+            Cbor4iiError::CastOverflow { name } => DecodeError::CastOverflow { name },
+            Cbor4iiError::ArithmeticOverflow { name, ty } => {
+                DecodeError::ArithmeticOverflow { name, ty }
+            }
+            Cbor4iiError::DepthOverflow { name } => DecodeError::DepthOverflow { name },
+            // Future-proof against new upstream variants without an SDK bump; loses structured info
+            // but preserves the Display string.
             _ => DecodeError::Msg(err.to_string()),
         }
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -214,7 +214,7 @@ impl<'a, W: enc::Write> serde::Serializer for &'a mut Serializer<W> {
         variant: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error> {
-        enc::MapStartBounded(1).encode(&mut self.writer)?;
+        types::Map::bounded(1, &mut self.writer)?;
         variant.encode(&mut self.writer)?;
         value.serialize(self)
     }
@@ -226,7 +226,7 @@ impl<'a, W: enc::Write> serde::Serializer for &'a mut Serializer<W> {
 
     #[inline]
     fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        enc::ArrayStartBounded(len).encode(&mut self.writer)?;
+        types::Array::bounded(len, &mut self.writer)?;
         Ok(BoundedCollect { ser: self })
     }
 
@@ -247,9 +247,9 @@ impl<'a, W: enc::Write> serde::Serializer for &'a mut Serializer<W> {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        enc::MapStartBounded(1).encode(&mut self.writer)?;
+        types::Map::bounded(1, &mut self.writer)?;
         variant.encode(&mut self.writer)?;
-        enc::ArrayStartBounded(len).encode(&mut self.writer)?;
+        types::Array::bounded(len, &mut self.writer)?;
         Ok(BoundedCollect { ser: self })
     }
 
@@ -264,7 +264,7 @@ impl<'a, W: enc::Write> serde::Serializer for &'a mut Serializer<W> {
         _name: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        enc::MapStartBounded(len).encode(&mut self.writer)?;
+        types::Map::bounded(len, &mut self.writer)?;
         Ok(CollectMap::new(self))
     }
 
@@ -276,9 +276,9 @@ impl<'a, W: enc::Write> serde::Serializer for &'a mut Serializer<W> {
         variant: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        enc::MapStartBounded(1).encode(&mut self.writer)?;
+        types::Map::bounded(1, &mut self.writer)?;
         variant.encode(&mut self.writer)?;
-        enc::MapStartBounded(len).encode(&mut self.writer)?;
+        types::Map::bounded(len, &mut self.writer)?;
         Ok(CollectMap::new(self))
     }
 
@@ -326,7 +326,7 @@ impl<'a, W: enc::Write> CollectSeq<'a, W> {
     /// the number of elements, which is then written before the elements are.
     fn new(ser: &'a mut Serializer<W>, len: Option<usize>) -> Result<Self, EncodeError<W::Error>> {
         let mem_ser = if let Some(len) = len {
-            enc::ArrayStartBounded(len).encode(&mut ser.writer)?;
+            types::Array::bounded(len, &mut ser.writer)?;
             None
         } else {
             Some(Serializer::new(BufWriter::new(Vec::new())))
@@ -365,7 +365,7 @@ impl<W: enc::Write> serde::ser::SerializeSeq for CollectSeq<'_, W> {
         // Data was buffered in order to be able to write out the number of elements before they
         // are serialized.
         if let Some(ser) = self.mem_ser {
-            enc::ArrayStartBounded(self.count).encode(&mut self.ser.writer)?;
+            types::Array::bounded(self.count, &mut self.ser.writer)?;
             self.ser.writer.push(&ser.into_inner().into_inner())?;
         }
 
@@ -500,7 +500,7 @@ where
 
     #[inline]
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        enc::MapStartBounded(self.entries.len()).encode(&mut self.ser.writer)?;
+        types::Map::bounded(self.entries.len(), &mut self.ser.writer)?;
         self.end()
     }
 }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -160,9 +160,9 @@ fn test_rejected_tag() {
         de::from_slice(&[0xd9, 0xd9, 0xf7, 0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
     assert!(matches!(
         ipld.unwrap_err(),
-        DecodeError::TypeMismatch {
+        DecodeError::Mismatch {
             name: "CBOR tag",
-            byte: 0xf7
+            found: 0xf7
         }
     ));
 }
@@ -187,10 +187,7 @@ fn test_crazy_list() {
 #[test]
 fn test_nan() {
     let ipld: Result<f64, _> = de::from_slice(b"\xf9\x7e\x00");
-    assert!(matches!(
-        ipld.unwrap_err(),
-        DecodeError::TypeMismatch { .. }
-    ));
+    assert!(matches!(ipld.unwrap_err(), DecodeError::Mismatch { .. }));
 }
 
 #[test]
@@ -312,14 +309,14 @@ fn test_stream_deserializer_trailing_data() {
     assert_eq!(value_1, "foobar");
 
     // we should get back an Eof error
-    assert!(matches!(i.next(), Some(Err(DecodeError::Eof))));
+    assert!(matches!(i.next(), Some(Err(DecodeError::Eof { .. }))));
 }
 
 #[test]
 fn crash() {
     let file = include_bytes!("crash.cbor");
     let value_result: Result<Ipld, _> = de::from_slice(file);
-    assert!(matches!(value_result.unwrap_err(), DecodeError::Eof));
+    assert!(matches!(value_result.unwrap_err(), DecodeError::Eof { .. }));
 }
 
 use serde_ipld_dagcbor::de::from_slice;
@@ -365,7 +362,7 @@ fn invalid_string() {
     let result = serde_ipld_dagcbor::from_slice::<Ipld>(&input);
     assert!(matches!(
         result.unwrap_err(),
-        DecodeError::InvalidUtf8 { .. }
+        DecodeError::RequireUtf8 { .. }
     ));
 }
 
@@ -477,11 +474,11 @@ fn test_default_values() {
                 b: "yep".to_string(),
             }),
         },
-        // [202,"nup",false] has too many elements so it errors with RequireLength
+        // [202,"nup",false] has too many elements so it errors with LengthMismatch
         TestCase {
             hex: "8318ca636e7570f4",
             expected: Expected::Err(
-                |err| matches!(err, DecodeError::RequireLength{ name, expect, value} if *name == "TupleWithDefaultsStruct" && *expect == 2 && *value == 3),
+                |err| matches!(err, DecodeError::LengthMismatch{ name, expect, value} if *name == "TupleWithDefaultsStruct" && *expect == 2 && *value == 3),
             ),
         },
     ];
@@ -511,11 +508,11 @@ fn test_default_values() {
                 bop: 606,
             }),
         },
-        // [505,[202,"nup",false],606] has too many elements on inner so it errors with RequireLength
+        // [505,[202,"nup",false],606] has too many elements on inner so it errors with LengthMismatch
         TestCase {
             hex: "831901f98318ca636e7570f419025e",
             expected: Expected::Err(
-                |err| matches!(err, DecodeError::RequireLength{ name, expect, value} if *name == "TupleWithDefaultsStruct" && *expect == 2 && *value == 3),
+                |err| matches!(err, DecodeError::LengthMismatch{ name, expect, value} if *name == "TupleWithDefaultsStruct" && *expect == 2 && *value == 3),
             ),
         },
         // [505,[]]
@@ -589,13 +586,13 @@ fn test_default_values() {
         // [[1],2] -> error because inner has too few elements
         TestCase {
             hex: "82820102",
-            expected: Expected::Err(|err| matches!(err, DecodeError::Eof)),
+            expected: Expected::Err(|err| matches!(err, DecodeError::Eof { .. })),
         },
         // [[1,2,3],4] -> error because inner has too many elements
         TestCase {
             hex: "828301020304",
             expected: Expected::Err(
-                |err| matches!(err, DecodeError::RequireLength{ name, expect, value} if *name == "TupleIntInner" && *expect == 2 && *value == 3),
+                |err| matches!(err, DecodeError::LengthMismatch{ name, expect, value} if *name == "TupleIntInner" && *expect == 2 && *value == 3),
             ),
         },
         // [[1,2]] + 3 -> error because there's a trailing element
@@ -607,7 +604,7 @@ fn test_default_values() {
         TestCase {
             hex: "8183010203",
             expected: Expected::Err(
-                |err| matches!(err, DecodeError::RequireLength{ name, expect, value} if *name == "TupleIntInner" && *expect == 2 && *value == 3),
+                |err| matches!(err, DecodeError::LengthMismatch{ name, expect, value} if *name == "TupleIntInner" && *expect == 2 && *value == 3),
             ),
         },
     ];


### PR DESCRIPTION
Bumps the `cbor4ii` to 1.x.y track (`1.2.2`).

Note - the decoding error enum is a **breaking change** the crate consumers.