### PR TITLE
fix: make sure that only string keys can be (de)serialized

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -714,7 +714,13 @@ impl<'de, R: dec::Read<'de>> de::MapAccess<'de> for Accessor<'_, R> {
         K: de::DeserializeSeed<'de>,
     {
         if self.len > 0 {
+            let name = "map key";
             self.len -= 1;
+            // Map keys must be strings in DAG-CBOR.
+            let byte = peek_one(name, &mut self.de.reader)?;
+            if dec::if_major(byte) != major::STRING {
+                return Err(DecodeError::Mismatch { name, found: byte });
+            }
             Ok(Some(seed.deserialize(&mut *self.de)?))
         } else {
             Ok(None)

--- a/src/de.rs
+++ b/src/de.rs
@@ -715,12 +715,12 @@ impl<'de, R: dec::Read<'de>> de::MapAccess<'de> for Accessor<'_, R> {
     {
         if self.len > 0 {
             let name = "map key";
-            self.len -= 1;
             // Map keys must be strings in DAG-CBOR.
             let byte = peek_one(name, &mut self.de.reader)?;
             if dec::if_major(byte) != major::STRING {
                 return Err(DecodeError::Mismatch { name, found: byte });
             }
+            self.len -= 1;
             Ok(Some(seed.deserialize(&mut *self.de)?))
         } else {
             Ok(None)

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -8,8 +8,9 @@ pub use cbor4ii::core::utils::BufWriter;
 #[cfg(feature = "std")]
 use cbor4ii::core::utils::IoWriter;
 use cbor4ii::core::{
+    dec,
     enc::{self, Encode},
-    types,
+    major, types,
 };
 use ipld_core::cid::serde::CID_SERDE_PRIVATE_IDENTIFIER;
 use serde::{ser, Serialize};
@@ -490,6 +491,12 @@ where
         let mut mem_serializer = Serializer::new(&mut self.buffer);
         key.serialize(&mut mem_serializer)
             .map_err(|_| EncodeError::Msg("Map key cannot be serialized.".to_string()))?;
+        // Map keys must be strings in DAG-CBOR.
+        if let Some(byte) = self.buffer.buffer().first() {
+            if dec::if_major(*byte) != major::STRING {
+                return Err(EncodeError::Msg("Map keys must be strings".into()));
+            }
+        }
         Ok(())
     }
 

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -110,6 +110,38 @@ fn test_object() {
 }
 
 #[test]
+fn test_map_integer_key_rejected() {
+    // {1: 2} — integer key (major type 0), not a string.
+    let ipld: Result<Ipld, _> = de::from_slice(b"\xa1\x01\x02");
+    assert!(
+        matches!(
+            ipld.unwrap_err(),
+            DecodeError::Mismatch {
+                name: "map key",
+                found: 0x01,
+            }
+        ),
+        "expected map key mismatch"
+    );
+}
+
+#[test]
+fn test_map_bytes_key_rejected() {
+    // {h'01': 2} — byte-string key (major type 2), not a string.
+    let ipld: Result<Ipld, _> = de::from_slice(b"\xa1\x41\x01\x02");
+    assert!(
+        matches!(
+            ipld.unwrap_err(),
+            DecodeError::Mismatch {
+                name: "map key",
+                found: 0x41,
+            }
+        ),
+        "expected map key mismatch"
+    );
+}
+
+#[test]
 fn test_indefinite_object_error() {
     let ipld: Result<Ipld, _> = de::from_slice(b"\xbfaa\x01ab\x9f\x02\x03\xff\xff");
     let mut object = BTreeMap::new();

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -110,35 +110,33 @@ fn test_object() {
 }
 
 #[test]
-fn test_map_integer_key_rejected() {
-    // {1: 2} — integer key (major type 0), not a string.
-    let ipld: Result<Ipld, _> = de::from_slice(b"\xa1\x01\x02");
-    assert!(
-        matches!(
-            ipld.unwrap_err(),
-            DecodeError::Mismatch {
-                name: "map key",
-                found: 0x01,
-            }
-        ),
-        "expected map key mismatch"
-    );
-}
-
-#[test]
-fn test_map_bytes_key_rejected() {
-    // {h'01': 2} — byte-string key (major type 2), not a string.
-    let ipld: Result<Ipld, _> = de::from_slice(b"\xa1\x41\x01\x02");
-    assert!(
-        matches!(
-            ipld.unwrap_err(),
-            DecodeError::Mismatch {
-                name: "map key",
-                found: 0x41,
-            }
-        ),
-        "expected map key mismatch"
-    );
+fn test_non_string_map_keys_rejected() {
+    // Each case is a one-entry map (0xa1) whose key uses a non-string major type.
+    let cases: &[(&[u8], &str)] = &[
+        (b"\xa1\x01\x02", "unsigned integer (major 0)"),
+        (b"\xa1\x20\x02", "negative integer (major 1)"),
+        (b"\xa1\x41\x01\x02", "byte string (major 2)"),
+        (b"\xa1\x80\x02", "array (major 4)"),
+        (b"\xa1\xa0\x02", "map (major 5)"),
+        (b"\xa1\xd8\x2a\x58\x25\x00\x01\x55\x12\x20\x2c\x26\xb4\x6b\x68\xff\xc6\x8f\xf9\x9b\x45\x3c\x1d\x30\x41\x34\x13\x42\x2d\x70\x64\x83\xbf\xa0\xf9\x8a\x5e\x88\x62\x66\xe7\xae\x02", "CID/tag 42 (major 6)"),
+        (b"\xa1\xf4\x02", "bool false (major 7)"),
+        (b"\xa1\xf5\x02", "bool true (major 7)"),
+        (b"\xa1\xf6\x02", "null (major 7)"),
+        (b"\xa1\xfa\x3f\x80\x00\x00\x02", "float (major 7)"),
+    ];
+    for (bytes, what) in cases {
+        let ipld: Result<Ipld, _> = de::from_slice(bytes);
+        let err = ipld.unwrap_err();
+        // The second byte is the actual type that is reported in error messages.
+        let found = &bytes[1];
+        assert!(
+            matches!(&err, DecodeError::Mismatch { name: "map key", found: f } if f == found),
+            "{}: expected map key mismatch with found={:#04x}, got {:?}",
+            what,
+            found,
+            err
+        );
+    }
 }
 
 #[test]

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -1,5 +1,7 @@
+use std::str::FromStr;
 use std::{collections::BTreeMap, iter};
 
+use ipld_core::cid::Cid;
 use serde::de::value::{self, MapDeserializer, SeqDeserializer};
 use serde_bytes::{ByteBuf, Bytes};
 use serde_derive::Serialize;
@@ -32,6 +34,14 @@ fn test_object() {
     let vec = to_vec(&object).unwrap();
     let test_object = from_slice(&vec[..]).unwrap();
     assert_eq!(object, test_object);
+}
+
+#[test]
+fn test_object_charkey() {
+    let mut object = BTreeMap::new();
+    object.insert('c', 0u8);
+    let vec = to_vec(&object).unwrap();
+    assert_eq!(vec, b"\xa1\x61\x63\x00");
 }
 
 #[test]
@@ -254,27 +264,33 @@ fn test_struct_variant_canonical() {
 }
 
 #[test]
-fn test_map_integer_key_rejected() {
-    let mut object = BTreeMap::new();
-    object.insert(1u32, "a");
-    object.insert(2u32, "b");
-    let err = to_vec(&object).unwrap_err();
-    assert!(
-        matches!(&err, EncodeError::Msg(msg) if msg.contains("Map keys must be strings")),
-        "unexpected error: {:?}",
-        err
-    );
-}
+fn test_non_string_map_keys_rejected() {
+    // Serialize a single-entry map `{key: 0}` and expect it to be rejected
+    // because the key is not a string. `f64` is intentionally not tested here:
+    // it is the only basic type that isn't `Ord` (so it can't be a `BTreeMap`
+    // key), and the encoder rejects purely by CBOR major type, so floats
+    // (major type 7) are already covered by the `bool` and `null` keys.
+    fn assert_rejected<K: Ord + serde::Serialize>(key: K, what: &str) {
+        let mut map = BTreeMap::new();
+        map.insert(key, 0u8);
+        let err = to_vec(&map).unwrap_err();
+        assert!(
+            matches!(&err, EncodeError::Msg(msg) if msg.contains("Map keys must be strings")),
+            "{}: unexpected error: {:?}",
+            what,
+            err
+        );
+    }
 
-#[test]
-fn test_map_bytes_key_rejected() {
-    let mut object = BTreeMap::new();
-    object.insert(ByteBuf::from(vec![1u8]), "a");
-    object.insert(ByteBuf::from(vec![2u8]), "b");
-    let err = to_vec(&object).unwrap_err();
-    assert!(
-        matches!(&err, EncodeError::Msg(msg) if msg.contains("Map keys must be strings")),
-        "unexpected error: {:?}",
-        err
+    assert_rejected(1u64, "unsigned integer");
+    assert_rejected(-1i64, "negative integer");
+    assert_rejected(ByteBuf::from(vec![1u8]), "byte string");
+    assert_rejected(vec![1u8], "array");
+    assert_rejected(true, "bool");
+    assert_rejected((), "null (unit)");
+    assert_rejected(Option::<u8>::None, "null (none)");
+    assert_rejected(
+        Cid::from_str("bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy").unwrap(),
+        "CID (tag 42)",
     );
 }

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -6,7 +6,7 @@ use serde_derive::Serialize;
 use serde_ipld_dagcbor::{
     from_slice,
     ser::{BufWriter, Serializer},
-    to_vec,
+    to_vec, EncodeError,
 };
 
 #[test]
@@ -251,4 +251,30 @@ fn test_struct_variant_canonical() {
         first_bytes,
         b"\xa1\x64Data\xa3\x61a\x01\x61b\x02\x63abc\x03"
     )
+}
+
+#[test]
+fn test_map_integer_key_rejected() {
+    let mut object = BTreeMap::new();
+    object.insert(1u32, "a");
+    object.insert(2u32, "b");
+    let err = to_vec(&object).unwrap_err();
+    assert!(
+        matches!(&err, EncodeError::Msg(msg) if msg.contains("Map keys must be strings")),
+        "unexpected error: {:?}",
+        err
+    );
+}
+
+#[test]
+fn test_map_bytes_key_rejected() {
+    let mut object = BTreeMap::new();
+    object.insert(ByteBuf::from(vec![1u8]), "a");
+    object.insert(ByteBuf::from(vec![2u8]), "b");
+    let err = to_vec(&object).unwrap_err();
+    assert!(
+        matches!(&err, EncodeError::Msg(msg) if msg.contains("Map keys must be strings")),
+        "unexpected error: {:?}",
+        err
+    );
 }


### PR DESCRIPTION
DAG-CBOR only allows strings as keys for maps. Make sure that only those can be encoded or decoded.

Fixes parts of #41.