### PR TITLE
fix: only allow minimally encoded CID tag

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -209,15 +209,23 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        let tag = types::Tag::tag(&mut self.reader)?;
-
-        match tag {
-            CBOR_TAGS_CID => visitor.visit_newtype_struct(&mut CidDeserializer(self)),
-            _ => Err(DecodeError::Mismatch {
-                name: "CBOR tag",
-                found: tag as u8,
-            }),
+        // DAG-CBOR only supports tag 42 (CID), encoded minimally as `0xd8 0x2a`.
+        let head = pull_one("tag head", &mut self.reader)?;
+        if head != 0xd8 {
+            return Err(DecodeError::Mismatch {
+                name: "CBOR tag head",
+                found: head,
+            });
         }
+
+        let tag = pull_one("tag", &mut self.reader)?;
+        if tag != CBOR_TAGS_CID {
+            return Err(DecodeError::Mismatch {
+                name: "CBOR tag",
+                found: tag,
+            });
+        }
+        visitor.visit_newtype_struct(&mut CidDeserializer(self))
     }
 
     /// This method should be called after a value has been deserialized to ensure there is no

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,4 +145,4 @@ pub use crate::ser::to_writer;
 pub const DAG_CBOR_CODE: u64 = 0x71;
 
 /// The CBOR tag that is used for CIDs.
-const CBOR_TAGS_CID: u64 = 42;
+const CBOR_TAGS_CID: u8 = 42;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -618,7 +618,7 @@ where
         // The bytes of the CID is prefixed with a null byte when encoded as CBOR.
         let prefixed = [&[0x00], value].concat();
         // CIDs are serialized with CBOR tag 42.
-        types::Tag(CBOR_TAGS_CID, types::Bytes(&prefixed[..])).encode(&mut self.0.writer)?;
+        types::Tag(CBOR_TAGS_CID.into(), types::Bytes(&prefixed[..])).encode(&mut self.0.writer)?;
         Ok(())
     }
 

--- a/tests/cid.rs
+++ b/tests/cid.rs
@@ -328,21 +328,20 @@ fn test_cid_non_minimally_encoded() {
     // Strip off the CBOR tag.
     let without_tag = &cid_encoded[2..];
 
+    // DAG-CBOR requires tags to be encoded minimally. Tag 42 must use the 1-byte
+    // form `0xd8 0x2a`; longer forms must be rejected.
     let tag_2_bytes_encoded = [&[0xd9, 0x00, 0x2a], without_tag].concat();
-    let tag_2_bytes_decoded: Cid = from_slice(&tag_2_bytes_encoded).unwrap();
-    assert_eq!(tag_2_bytes_decoded, cid);
+    assert!(from_slice::<Cid>(&tag_2_bytes_encoded).is_err());
 
     let tag_4_bytes_encoded = [&[0xda, 0x00, 0x00, 0x00, 0x2a], without_tag].concat();
-    let tag_4_bytes_decoded: Cid = from_slice(&tag_4_bytes_encoded).unwrap();
-    assert_eq!(tag_4_bytes_decoded, cid);
+    assert!(from_slice::<Cid>(&tag_4_bytes_encoded).is_err());
 
     let tag_8_bytes_encoded = [
         &[0xdb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2a],
         without_tag,
     ]
     .concat();
-    let tag_8_bytes_decoded: Cid = from_slice(&tag_8_bytes_encoded).unwrap();
-    assert_eq!(tag_8_bytes_decoded, cid);
+    assert!(from_slice::<Cid>(&tag_8_bytes_encoded).is_err());
 }
 
 #[test]

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -186,13 +186,23 @@ fn test_float() {
 
 #[test]
 fn test_rejected_tag() {
-    let ipld: Result<Ipld, _> =
-        de::from_slice(&[0xd9, 0xd9, 0xf7, 0x66, 0x66, 0x6f, 0x6f, 0x62, 0x61, 0x72]);
+    // Tag 42, but not minimally encoded.
+    let ipld: Result<Ipld, _> = de::from_slice(&[0xd9, 0x00, 0x2a, 0x43, 0x00, 0x01, 0x02]);
+    assert!(matches!(
+        ipld.unwrap_err(),
+        DecodeError::Mismatch {
+            name: "CBOR tag head",
+            found: 0xd9
+        }
+    ));
+
+    // Minimally encoded tag, but not tag 42.
+    let ipld: Result<Ipld, _> = de::from_slice(&[0xd8, 0x28, 0x42, 0x00, 0x01]);
     assert!(matches!(
         ipld.unwrap_err(),
         DecodeError::Mismatch {
             name: "CBOR tag",
-            found: 0xf7
+            found: 0x28
         }
     ));
 }


### PR DESCRIPTION
Integers should always be minimally encoded, so should be the header of a tag.