### PR TITLE
fix: don't allow f32/f64 NaN or infinity

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -367,9 +367,6 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
         u32,        deserialize_u32,        visit_u32;
         u64,        deserialize_u64,        visit_u64;
         u128,       deserialize_u128,       visit_u128;
-
-        // f32 deserialize is handled as a special case below
-        f64,        deserialize_f64,        visit_f64;
     );
 
     #[inline]
@@ -388,16 +385,25 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
             marker::F32 => {
                 // Note: f32 encoding is not valid in strict DAG-CBOR.
                 let value = <f32>::decode(&mut self.reader)?;
+                // DAG-CBOR forbids NaN and Infinity.
+                if !value.is_finite() {
+                    return Err(DecodeError::Mismatch { name, found: byte });
+                }
                 visitor.visit_f32(value)
             }
             marker::F64 => {
                 // DAG-CBOR always uses f64 encoding, even for f32 values
                 let value = <f64>::decode(&mut self.reader)?;
 
+                // DAG-CBOR forbids NaN and Infinity.
+                if !value.is_finite() {
+                    return Err(DecodeError::Mismatch { name, found: byte });
+                }
+
                 let f32_value = value as f32;
 
                 // Check if conversion causes overflow to infinity
-                if !f32_value.is_finite() && value.is_finite() {
+                if !f32_value.is_finite() {
                     // The f64 value is finite but becomes infinite when converted to f32
                     return Err(DecodeError::Msg("Float value out of range for f32".into()));
                 }
@@ -416,6 +422,21 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
             }
             _ => Err(DecodeError::Mismatch { name, found: byte }),
         }
+    }
+
+    #[inline]
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let name = "f64";
+        let byte = peek_one(name, &mut self.reader)?;
+        let value = <f64>::decode(&mut self.reader)?;
+        // DAG-CBOR forbids NaN and Infinity.
+        if !value.is_finite() {
+            return Err(DecodeError::Mismatch { name, found: byte });
+        }
+        visitor.visit_f64(value)
     }
 
     #[inline]

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -225,8 +225,61 @@ fn test_crazy_list() {
 }
 
 #[test]
-fn test_nan() {
+fn test_nan_f16() {
     let ipld: Result<f64, _> = de::from_slice(b"\xf9\x7e\x00");
+    assert!(matches!(ipld.unwrap_err(), DecodeError::Mismatch { .. }));
+}
+
+#[test]
+fn test_nan_f32() {
+    // f32-encoded NaN deserialized as f32.
+    let ipld: Result<f32, _> = de::from_slice(b"\xfa\x7f\xc0\x00\x00");
+    assert!(matches!(ipld.unwrap_err(), DecodeError::Mismatch { .. }));
+    // f64-encoded NaN deserialized as f32.
+    let ipld: Result<f32, _> = de::from_slice(b"\xfb\x7f\xf8\x00\x00\x00\x00\x00\x00");
+    assert!(matches!(ipld.unwrap_err(), DecodeError::Mismatch { .. }));
+}
+
+#[test]
+fn test_nan_f64() {
+    let ipld: Result<f64, _> = de::from_slice(b"\xfb\x7f\xf8\x00\x00\x00\x00\x00\x00");
+    assert!(matches!(ipld.unwrap_err(), DecodeError::Mismatch { .. }));
+}
+
+#[test]
+fn test_nan_via_ipld() {
+    // f64-encoded NaN must also be rejected when going through `deserialize_any`.
+    let ipld: Result<Ipld, _> = de::from_slice(b"\xfb\x7f\xf8\x00\x00\x00\x00\x00\x00");
+    assert!(matches!(ipld.unwrap_err(), DecodeError::Mismatch { .. }));
+}
+
+#[test]
+fn test_infinity_f16() {
+    // f16-encoded +Infinity deserialized as f32.
+    let ipld: Result<f32, _> = de::from_slice(b"\xf9\x7c\x00");
+    assert!(matches!(ipld.unwrap_err(), DecodeError::Mismatch { .. }));
+    // f16-encoded -Infinity deserialized as f32.
+    let ipld: Result<f64, _> = de::from_slice(b"\xf9\xfc\x00");
+    assert!(matches!(ipld.unwrap_err(), DecodeError::Mismatch { .. }));
+}
+
+#[test]
+fn test_infinity_f32() {
+    // f32-encoded +Infinity deserialized as f32.
+    let ipld: Result<f32, _> = de::from_slice(b"\xfa\x7f\x80\x00\x00");
+    assert!(matches!(ipld.unwrap_err(), DecodeError::Mismatch { .. }));
+    // f64-encoded -Infinity deserialized as f32.
+    let ipld: Result<f32, _> = de::from_slice(b"\xfb\xff\xf0\x00\x00\x00\x00\x00\x00");
+    assert!(matches!(ipld.unwrap_err(), DecodeError::Mismatch { .. }));
+}
+
+#[test]
+fn test_infinity_f64() {
+    // +Infinity
+    let ipld: Result<f64, _> = de::from_slice(b"\xfb\x7f\xf0\x00\x00\x00\x00\x00\x00");
+    assert!(matches!(ipld.unwrap_err(), DecodeError::Mismatch { .. }));
+    // -Infinity
+    let ipld: Result<f64, _> = de::from_slice(b"\xfb\xff\xf0\x00\x00\x00\x00\x00\x00");
     assert!(matches!(ipld.unwrap_err(), DecodeError::Mismatch { .. }));
 }
 


### PR DESCRIPTION
The short f16 NaN was already erroring, but the longer f32 and f64 versions should also error. DAG-CBOR does neither support NaN, nor Infinity.