### PR TITLE
fix: make sure things are minimally encoded

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -283,19 +283,32 @@ impl<'de, R: dec::Read<'de>> Deserializer<R> {
     }
 }
 
-macro_rules! deserialize_type {
+macro_rules! deserialize_int {
     ( @ $t:ty , $name:ident , $visit:ident ) => {
         #[inline]
         fn $name<V>(self, visitor: V) -> Result<V::Value, Self::Error>
         where V: Visitor<'de>
         {
+            let name = stringify!($t);
+            let head = peek_one(name, &mut self.reader)?;
             let value = <$t>::decode(&mut self.reader)?;
+            // DAG-CBOR requires the head's argument to be minimally encoded. For an unsigned head
+            // (major type 0) the argument is `value`. For a negative head (major type 1) it is
+            // `-1 - value`, which in two's complement is the bitwise complement `!value`. In each
+            // branch the argument is non-negative and within `u64`, so the cast is exact.
+            match dec::if_major(head) {
+                major::UNSIGNED => check_minimal(name, head, value as u64)?,
+                major::NEGATIVE => check_minimal(name, head, !value as u64)?,
+                // cbor4ii allows decoding of CBOR big integers (type 6, tags 2 and 3) as
+                // `i128`/`u128. Reject those.
+                _ => return Err(DecodeError::Unsupported { name, found: head }),
+            }
             visitor.$visit(value)
         }
     };
     ( $( $t:ty , $name:ident , $visit:ident );* $( ; )? ) => {
         $(
-            deserialize_type!(@ $t, $name, $visit);
+            deserialize_int!(@ $t, $name, $visit);
         )*
     };
 }
@@ -321,6 +334,9 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
                 // CBOR supports negative integers up to -2^64 which is less than i64::MIN. Only
                 // treat it as i128, if it is outside the i64 range.
                 let value = i128::decode(&mut de.reader)?;
+                // Enforce minimal encoding; the negative head's argument is `-1 - value`, which in
+                // two's complement is the bitwise complement `!value`.
+                check_minimal(name, byte, !value as u64)?;
                 match i64::try_from(value) {
                     Ok(value_i64) => visitor.visit_i64(value_i64),
                     Err(_) => visitor.visit_i128(value),
@@ -353,9 +369,16 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
         }
     }
 
-    deserialize_type!(
-        bool,       deserialize_bool,       visit_bool;
+    #[inline]
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let value = <bool>::decode(&mut self.reader)?;
+        visitor.visit_bool(value)
+    }
 
+    deserialize_int!(
         i8,         deserialize_i8,         visit_i8;
         i16,        deserialize_i16,        visit_i16;
         i32,        deserialize_i32,        visit_i32;
@@ -455,7 +478,11 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        match <types::Bytes<Cow<[u8]>>>::decode(&mut self.reader)?.0 {
+        let name = "bytes";
+        let head = peek_one(name, &mut self.reader)?;
+        let bytes = <types::Bytes<Cow<[u8]>>>::decode(&mut self.reader)?.0;
+        check_minimal(name, head, bytes.len() as u64)?;
+        match bytes {
             Cow::Borrowed(buf) => visitor.visit_borrowed_bytes(buf),
             Cow::Owned(buf) => visitor.visit_byte_buf(buf),
         }
@@ -474,7 +501,11 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        match <Cow<str>>::decode(&mut self.reader)? {
+        let name = "string";
+        let head = peek_one(name, &mut self.reader)?;
+        let string = <Cow<str>>::decode(&mut self.reader)?;
+        check_minimal(name, head, string.len() as u64)?;
+        match string {
             Cow::Borrowed(buf) => visitor.visit_borrowed_str(buf),
             Cow::Owned(buf) => visitor.visit_string(buf),
         }
@@ -681,20 +712,28 @@ struct Accessor<'a, R> {
 impl<'de, 'a, R: dec::Read<'de>> Accessor<'a, R> {
     #[inline]
     fn array(de: &'a mut Deserializer<R>) -> Result<Accessor<'a, R>, DecodeError<R::Error>> {
-        let len = types::Array::len(&mut de.reader)?;
-        len.map_or_else(
-            || Err(DecodeError::IndefiniteSize),
-            move |len| Ok(Accessor { de, len }),
-        )
+        let name = "array";
+        let head = peek_one(name, &mut de.reader)?;
+        match types::Array::len(&mut de.reader)? {
+            None => Err(DecodeError::IndefiniteSize),
+            Some(len) => {
+                check_minimal(name, head, len as u64)?;
+                Ok(Accessor { de, len })
+            }
+        }
     }
 
     #[inline]
     fn map(de: &'a mut Deserializer<R>) -> Result<Accessor<'a, R>, DecodeError<R::Error>> {
-        let len = types::Map::len(&mut de.reader)?;
-        len.map_or_else(
-            || Err(DecodeError::IndefiniteSize),
-            move |len| Ok(Accessor { de, len }),
-        )
+        let name = "map";
+        let head = peek_one(name, &mut de.reader)?;
+        match types::Map::len(&mut de.reader)? {
+            None => Err(DecodeError::IndefiniteSize),
+            Some(len) => {
+                check_minimal(name, head, len as u64)?;
+                Ok(Accessor { de, len })
+            }
+        }
     }
 }
 
@@ -874,7 +913,9 @@ impl<'de, 'a, R: dec::Read<'de>> de::Deserializer<'de> for &'a mut CidDeserializ
         match dec::if_major(byte) {
             major::BYTES => {
                 // CBOR encoded CIDs have a zero byte prefix we have to remove.
-                match <types::Bytes<Cow<[u8]>>>::decode(&mut self.0.reader)?.0 {
+                let bytes = <types::Bytes<Cow<[u8]>>>::decode(&mut self.0.reader)?.0;
+                check_minimal("cid", byte, bytes.len() as u64)?;
+                match bytes {
                     Cow::Borrowed(buf) => {
                         if buf.len() <= 1 || buf[0] != 0 {
                             Err(DecodeError::Msg("Invalid CID".into()))
@@ -925,4 +966,31 @@ impl<'de, 'a, R: dec::Read<'de>> de::Deserializer<'de> for &'a mut CidDeserializ
 #[inline]
 pub fn is_indefinite(byte: u8) -> bool {
     byte & marker::START == marker::START
+}
+
+/// Checks that a CBOR head was minimally encoded.
+///
+/// DAG-CBOR requires the argument of a head (an integer value, or the length of a byte string,
+/// text string, array or map, or a tag number) to be encoded in the shortest possible form. Given
+/// the `head` byte that was peeked before decoding and the `arg` value that was decoded from it,
+/// this verifies that the head used the smallest possible width.
+#[inline]
+fn check_minimal<E>(name: &'static str, head: u8, arg: u64) -> Result<(), DecodeError<E>> {
+    // The low 5 bits of the head are the "additional info" describing the argument width. As the
+    // width is already known, the encoding is minimal exactly when `arg` is too large to have used
+    // a narrower one, i.e. when it reaches the smallest value that width is needed for.
+    let min = match head & 0x1f {
+        0x18 => 24,
+        0x19 => 1 << 8,
+        0x1a => 1 << 16,
+        0x1b => 1 << 32,
+        // Inline values (0x00..=0x17) are always minimal; reserved and indefinite codes
+        // (0x1c..=0x1f) are rejected by the decoder before reaching this point.
+        _ => return Ok(()),
+    };
+    if arg >= min {
+        Ok(())
+    } else {
+        Err(DecodeError::NonMinimal { name, found: head })
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -150,6 +150,13 @@ pub enum DecodeError<E> {
     TrailingData,
     /// Indefinite sized item was encountered.
     IndefiniteSize,
+    /// An integer or length was not minimally encoded.
+    NonMinimal {
+        /// Type name.
+        name: &'static str,
+        /// The non-minimal head byte.
+        found: u8,
+    },
 }
 
 impl<E> From<E> for DecodeError<E> {

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -776,3 +776,158 @@ fn test_default_values() {
         }
     }
 }
+
+// DAG-CBOR requires integers and lengths to be encoded in the shortest possible form. The
+// following tests make sure that non-minimally encoded data is rejected, while the equivalent
+// minimal encoding is accepted.
+fn is_non_minimal(bytes: &[u8]) -> bool {
+    let result: Result<Ipld, _> = de::from_slice(bytes);
+    matches!(result.unwrap_err(), DecodeError::NonMinimal { .. })
+}
+
+#[test]
+fn test_unsigned_non_minimal() {
+    // The value 5 fits in the head, so any wider encoding is non-minimal.
+    assert!(is_non_minimal(&[0x18, 0x05]));
+    assert!(is_non_minimal(&[0x19, 0x00, 0x05]));
+    assert!(is_non_minimal(&[0x1a, 0x00, 0x00, 0x00, 0x05]));
+    assert!(is_non_minimal(&[
+        0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05
+    ]));
+
+    // The value 256 fits in 2 bytes, so 4- and 8-byte encodings are non-minimal.
+    assert!(is_non_minimal(&[0x1a, 0x00, 0x00, 0x01, 0x00]));
+
+    // The value 24 needs the 1-byte form, but here it is wrongly put in the 2-byte form.
+    assert!(is_non_minimal(&[0x19, 0x00, 0x18]));
+}
+
+#[test]
+fn test_unsigned_minimal_ok() {
+    assert_eq!(de::from_slice::<Ipld>(&[0x05]).unwrap(), Ipld::Integer(5));
+    assert_eq!(
+        de::from_slice::<Ipld>(&[0x18, 0x18]).unwrap(),
+        Ipld::Integer(24)
+    );
+    assert_eq!(
+        de::from_slice::<Ipld>(&[0x19, 0x01, 0x00]).unwrap(),
+        Ipld::Integer(256)
+    );
+    // The smallest values that need the 4- and 8-byte forms, so those widths are minimal here.
+    assert_eq!(
+        de::from_slice::<Ipld>(&[0x1a, 0x00, 0x01, 0x00, 0x00]).unwrap(),
+        Ipld::Integer(65536)
+    );
+    assert_eq!(
+        de::from_slice::<Ipld>(&[0x1b, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]).unwrap(),
+        Ipld::Integer(4294967296)
+    );
+}
+
+#[test]
+fn test_negative_non_minimal() {
+    // -1 (argument 0) fits in the head, so any wider encoding is non-minimal.
+    assert!(is_non_minimal(&[0x38, 0x00]));
+    assert!(is_non_minimal(&[0x39, 0x00, 0x00]));
+    assert!(is_non_minimal(&[0x3a, 0x00, 0x00, 0x00, 0x00]));
+    assert!(is_non_minimal(&[
+        0x3b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    ]));
+
+    // -1000 has argument 999 which fits in 2 bytes, so the 4-byte form is non-minimal.
+    assert!(is_non_minimal(&[0x3a, 0x00, 0x00, 0x03, 0xe7]));
+}
+
+#[test]
+fn test_negative_minimal_ok() {
+    assert_eq!(de::from_slice::<Ipld>(&[0x20]).unwrap(), Ipld::Integer(-1));
+    assert_eq!(
+        de::from_slice::<Ipld>(&[0x39, 0x03, 0xe7]).unwrap(),
+        Ipld::Integer(-1000)
+    );
+}
+
+#[test]
+fn test_byte_string_length_non_minimal() {
+    // A one byte byte string whose length (1) fits in the head, encoded in wider forms.
+    assert!(is_non_minimal(&[0x58, 0x01, 0xff]));
+    assert!(is_non_minimal(&[0x59, 0x00, 0x01, 0xff]));
+    assert!(is_non_minimal(&[0x5a, 0x00, 0x00, 0x00, 0x01, 0xff]));
+    assert!(is_non_minimal(&[
+        0x5b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xff
+    ]));
+}
+
+#[test]
+fn test_text_string_length_non_minimal() {
+    // A one character text string whose length (1) fits in the head, encoded in wider forms.
+    assert!(is_non_minimal(&[0x78, 0x01, 0x61]));
+    assert!(is_non_minimal(&[0x79, 0x00, 0x01, 0x61]));
+    assert!(is_non_minimal(&[0x7a, 0x00, 0x00, 0x00, 0x01, 0x61]));
+    assert!(is_non_minimal(&[
+        0x7b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x61
+    ]));
+}
+
+#[test]
+fn test_array_length_non_minimal() {
+    // A single element array whose length (1) fits in the head, encoded in wider forms.
+    assert!(is_non_minimal(&[0x98, 0x01, 0x01]));
+    assert!(is_non_minimal(&[0x99, 0x00, 0x01, 0x01]));
+    assert!(is_non_minimal(&[0x9a, 0x00, 0x00, 0x00, 0x01, 0x01]));
+    assert!(is_non_minimal(&[
+        0x9b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01
+    ]));
+}
+
+#[test]
+fn test_map_length_non_minimal() {
+    // A single entry map (key "a" => 1) whose length (1) fits in the head, encoded in wider forms.
+    assert!(is_non_minimal(&[0xb8, 0x01, 0x61, 0x61, 0x01]));
+    assert!(is_non_minimal(&[0xb9, 0x00, 0x01, 0x61, 0x61, 0x01]));
+    assert!(is_non_minimal(&[
+        0xba, 0x00, 0x00, 0x00, 0x01, 0x61, 0x61, 0x01
+    ]));
+    assert!(is_non_minimal(&[
+        0xbb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x61, 0x61, 0x01
+    ]));
+}
+
+#[test]
+fn test_lengths_minimal_ok() {
+    assert_eq!(
+        de::from_slice::<Ipld>(&[0x41, 0xff]).unwrap(),
+        Ipld::Bytes(vec![0xff])
+    );
+    assert_eq!(
+        de::from_slice::<Ipld>(&[0x61, 0x61]).unwrap(),
+        Ipld::String("a".to_string())
+    );
+    assert_eq!(
+        de::from_slice::<Ipld>(&[0x81, 0x01]).unwrap(),
+        Ipld::List(vec![Ipld::Integer(1)])
+    );
+}
+
+/// DAG-CBOR permits only tag 42 (CID). The CBOR bignum tags (tag 2 for positive, tag 3 for
+/// negative), which CBOR otherwise allows for integers that don't fit in 64 bits, must be rejected.
+#[test]
+fn test_bignum_tags_rejected() {
+    // `0xc2 0x41 0x01`: tag 2 (positive bignum) wrapping the byte string `[0x01]` (the value 1).
+    let positive_bignum = [0xc2, 0x41, 0x01];
+    assert!(matches!(
+        de::from_slice::<u128>(&positive_bignum).unwrap_err(),
+        DecodeError::Unsupported { .. }
+    ));
+    assert!(matches!(
+        de::from_slice::<i128>(&positive_bignum).unwrap_err(),
+        DecodeError::Unsupported { .. }
+    ));
+
+    // `0xc3 0x41 0x00`: tag 3 (negative bignum) wrapping the byte string `[0x00]` (the value -1).
+    let negative_bignum = [0xc3, 0x41, 0x00];
+    assert!(matches!(
+        de::from_slice::<i128>(&negative_bignum).unwrap_err(),
+        DecodeError::Unsupported { .. }
+    ));
+}

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -894,6 +894,20 @@ fn test_map_length_non_minimal() {
 }
 
 #[test]
+fn test_map_key_length_non_minimal() {
+    // A single entry map (key "a" => 1) where the key's text string length (1) fits in the head,
+    // but is encoded in wider forms.
+    assert!(is_non_minimal(&[0xa1, 0x78, 0x01, 0x61, 0x01]));
+    assert!(is_non_minimal(&[0xa1, 0x79, 0x00, 0x01, 0x61, 0x01]));
+    assert!(is_non_minimal(&[
+        0xa1, 0x7a, 0x00, 0x00, 0x00, 0x01, 0x61, 0x01
+    ]));
+    assert!(is_non_minimal(&[
+        0xa1, 0x7b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x61, 0x01
+    ]));
+}
+
+#[test]
 fn test_lengths_minimal_ok() {
     assert_eq!(
         de::from_slice::<Ipld>(&[0x41, 0xff]).unwrap(),

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -923,6 +923,39 @@ fn test_lengths_minimal_ok() {
     );
 }
 
+#[test]
+fn test_minimal_boundaries() {
+    // 23 (0x17) fits in the head byte, 24 (0x18) needs a following byte.
+    assert!(is_non_minimal(&[0x18, 0x17]));
+    assert_eq!(
+        de::from_slice::<Ipld>(&[0x18, 0x18]).unwrap(),
+        Ipld::Integer(24)
+    );
+
+    // 255 (0xff) fits in 1 byte, 256 (0x0100) needs 2.
+    assert!(is_non_minimal(&[0x19, 0x00, 0xff]));
+    assert_eq!(
+        de::from_slice::<Ipld>(&[0x19, 0x01, 0x00]).unwrap(),
+        Ipld::Integer(256)
+    );
+
+    // 65535 (0xffff) fits in 2 bytes, 65536 (0x010000) needs 4.
+    assert!(is_non_minimal(&[0x1a, 0x00, 0x00, 0xff, 0xff]));
+    assert_eq!(
+        de::from_slice::<Ipld>(&[0x1a, 0x00, 0x01, 0x00, 0x00]).unwrap(),
+        Ipld::Integer(65536)
+    );
+
+    // 4294967295 (0xffffffff) fits in 4 bytes, 4294967296 (0x0100000000) needs 8.
+    assert!(is_non_minimal(&[
+        0x1b, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff
+    ]));
+    assert_eq!(
+        de::from_slice::<Ipld>(&[0x1b, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]).unwrap(),
+        Ipld::Integer(4294967296)
+    );
+}
+
 /// DAG-CBOR permits only tag 42 (CID). The CBOR bignum tags (tag 2 for positive, tag 3 for
 /// negative), which CBOR otherwise allows for integers that don't fit in 64 bits, must be rejected.
 #[test]

--- a/tests/std_types.rs
+++ b/tests/std_types.rs
@@ -62,6 +62,26 @@ testcase!(test_i8_23, i8, 23, "17");
 testcase!(test_i8_24, i8, 24, "1818");
 testcase!(test_i8_neg_128, i8, -128, "387f");
 testcase!(test_u32_98745874, u32, 98745874, "1a05e2be12");
+testcase!(test_u64_max, u64, u64::MAX, "1bffffffffffffffff");
+testcase!(
+    test_u128_max_u64,
+    u128,
+    u64::MAX as u128,
+    "1bffffffffffffffff"
+);
+testcase!(
+    test_i128_max_u64,
+    i128,
+    u64::MAX as i128,
+    "1bffffffffffffffff"
+);
+testcase!(test_i64_min, i64, i64::MIN, "3b7fffffffffffffff");
+testcase!(
+    test_i128_min_cbor,
+    i128,
+    -(u64::MAX as i128 + 1),
+    "3bffffffffffffffff"
+);
 // In DAG-CBOR you cannot deserialize into f32, it's always f64.
 //testcase!(test_f32_1234_point_5, f32, 1234.5, "fb40934a0000000000");
 testcase!(test_f64_12345_point_6, f64, 12345.6, "fb40c81ccccccccccd");


### PR DESCRIPTION
Also fail on the decoding side if lengths are not minimally encoded.