### PR TITLE
fix: error on decoding duplicate keys

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1,8 +1,10 @@
 //! Deserialization.
 #[cfg(not(feature = "std"))]
 use alloc::borrow::Cow;
+use core::cmp::Ordering;
 use core::convert::{Infallible, TryFrom};
 use core::marker::PhantomData;
+use serde::de::IntoDeserializer;
 use serde::Deserialize;
 #[cfg(feature = "std")]
 use std::borrow::Cow;
@@ -704,40 +706,50 @@ where
     }
 }
 
-struct Accessor<'a, R> {
+struct Accessor<'de, 'a, R> {
     de: &'a mut Deserializer<R>,
     len: usize,
+    /// The previous map key, used to prevent duplicate keys.
+    last_key: Option<Cow<'de, str>>,
 }
 
-impl<'de, 'a, R: dec::Read<'de>> Accessor<'a, R> {
+impl<'de, 'a, R: dec::Read<'de>> Accessor<'de, 'a, R> {
     #[inline]
-    fn array(de: &'a mut Deserializer<R>) -> Result<Accessor<'a, R>, DecodeError<R::Error>> {
+    fn array(de: &'a mut Deserializer<R>) -> Result<Accessor<'de, 'a, R>, DecodeError<R::Error>> {
         let name = "array";
         let head = peek_one(name, &mut de.reader)?;
         match types::Array::len(&mut de.reader)? {
             None => Err(DecodeError::IndefiniteSize),
             Some(len) => {
                 check_minimal(name, head, len as u64)?;
-                Ok(Accessor { de, len })
+                Ok(Accessor {
+                    de,
+                    len,
+                    last_key: None,
+                })
             }
         }
     }
 
     #[inline]
-    fn map(de: &'a mut Deserializer<R>) -> Result<Accessor<'a, R>, DecodeError<R::Error>> {
+    fn map(de: &'a mut Deserializer<R>) -> Result<Accessor<'de, 'a, R>, DecodeError<R::Error>> {
         let name = "map";
         let head = peek_one(name, &mut de.reader)?;
         match types::Map::len(&mut de.reader)? {
             None => Err(DecodeError::IndefiniteSize),
             Some(len) => {
                 check_minimal(name, head, len as u64)?;
-                Ok(Accessor { de, len })
+                Ok(Accessor {
+                    de,
+                    len,
+                    last_key: None,
+                })
             }
         }
     }
 }
 
-impl<'de, R> de::SeqAccess<'de> for Accessor<'_, R>
+impl<'de, R> de::SeqAccess<'de> for Accessor<'de, '_, R>
 where
     R: dec::Read<'de>,
 {
@@ -762,7 +774,7 @@ where
     }
 }
 
-impl<'de, R: dec::Read<'de>> de::MapAccess<'de> for Accessor<'_, R> {
+impl<'de, R: dec::Read<'de>> de::MapAccess<'de> for Accessor<'de, '_, R> {
     type Error = DecodeError<R::Error>;
 
     #[inline]
@@ -777,8 +789,22 @@ impl<'de, R: dec::Read<'de>> de::MapAccess<'de> for Accessor<'_, R> {
             if dec::if_major(byte) != major::STRING {
                 return Err(DecodeError::Mismatch { name, found: byte });
             }
+
+            let key = <Cow<str>>::decode(&mut self.de.reader)?;
+            check_minimal(name, byte, key.len() as u64)?;
+            if let Some(last_key) = &self.last_key {
+                if dagcbor_key_cmp(last_key, &key) == Ordering::Equal {
+                    return Err(DecodeError::DuplicateKey);
+                }
+            }
+
             self.len -= 1;
-            Ok(Some(seed.deserialize(&mut *self.de)?))
+
+            // Cloning a borrowed `Cow` just copies the slice reference, so the common
+            // `from_slice` path stays allocation-free. Only `from_reader`, which already owns the
+            // decoded bytes, actually copies here.
+            self.last_key = Some(key.clone());
+            seed.deserialize(key.into_deserializer()).map(Some)
         } else {
             Ok(None)
         }
@@ -966,6 +992,14 @@ impl<'de, 'a, R: dec::Read<'de>> de::Deserializer<'de> for &'a mut CidDeserializ
 #[inline]
 pub fn is_indefinite(byte: u8) -> bool {
     byte & marker::START == marker::START
+}
+
+/// Compares two DAG-CBOR map keys to determine their required ordering.
+///
+/// DAG-CBOR sorts map keys low-to-high by length first, and then bytewise.
+#[inline]
+fn dagcbor_key_cmp(a: &str, b: &str) -> Ordering {
+    a.len().cmp(&b.len()).then_with(|| a.cmp(b))
 }
 
 /// Checks that a CBOR head was minimally encoded.

--- a/src/error.rs
+++ b/src/error.rs
@@ -157,6 +157,8 @@ pub enum DecodeError<E> {
         /// The non-minimal head byte.
         found: u8,
     },
+    /// Duplicate keys are not allowed in Maps.
+    DuplicateKey,
 }
 
 impl<E> From<E> for DecodeError<E> {

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -931,3 +931,11 @@ fn test_bignum_tags_rejected() {
         DecodeError::Unsupported { .. }
     ));
 }
+
+#[test]
+fn test_map_duplicate_keys() {
+    // {"a": 1, "a": 1 }
+    let result: Result<BTreeMap<String, u8>, _> =
+        de::from_slice(&[0xa2, 0x61, 0x61, 0x00, 0x61, 0x61, 0x01]);
+    assert!(matches!(result.unwrap_err(), DecodeError::DuplicateKey));
+}


### PR DESCRIPTION
Duplicate keys were only rejected when the `Ipld` enum was used, due to its visitor rejecting them. When decoding directly into another type (e.g. a `BTreeMap`), they were accepted.