### PR TITLE
chore: remove print statements from tests

### DIFF
--- a/tests/de.rs
+++ b/tests/de.rs
@@ -289,7 +289,6 @@ fn test_option_roundtrip() {
 
     let v = to_vec(&obj1).unwrap();
     let obj2: Result<Option<u32>, _> = de::from_slice(&v[..]);
-    println!("{:?}", obj2);
 
     assert_eq!(obj1, obj2.unwrap());
 }
@@ -299,7 +298,6 @@ fn test_option_none_roundtrip() {
     let obj1 = None;
 
     let v = to_vec(&obj1).unwrap();
-    println!("{:?}", v);
     let obj2: Result<Option<u32>, _> = de::from_slice(&v[..]);
 
     assert_eq!(obj1, obj2.unwrap());

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -17,7 +17,6 @@ struct EnumStruct {
 fn test_enum() {
     let enum_struct = EnumStruct { e: Enum::B };
     let raw = &to_vec(&enum_struct).unwrap();
-    println!("raw enum {:?}", raw);
     let re: EnumStruct = from_slice(raw).unwrap();
     assert_eq!(enum_struct, re);
 }
@@ -60,7 +59,6 @@ fn test_data_enum() {
         x: 3,
         y: "foo".to_owned(),
     };
-    println!("{:?}", &to_vec(&data_enum_c).unwrap());
     let re_c: DataEnum = from_slice(&to_vec(&data_enum_c).unwrap()).unwrap();
     assert_eq!(data_enum_c, re_c);
 }

--- a/tests/ipld.rs
+++ b/tests/ipld.rs
@@ -52,7 +52,6 @@ fn serde() {
     };
 
     let ipld = ipld_core::serde::to_ipld(data.clone()).unwrap();
-    println!("{:?}", ipld);
 
     let data_ser = serde_ipld_dagcbor::to_vec(&ipld).unwrap();
     let data_de_ipld: Ipld = serde_ipld_dagcbor::from_slice(&data_ser).unwrap();
@@ -97,10 +96,8 @@ fn struct_with_tuple_representation() {
     };
 
     let ipld = ipld_core::serde::to_ipld(st.clone()).unwrap();
-    println!("{:?}", ipld);
 
     let data_ser = serde_ipld_dagcbor::to_vec(&ipld).unwrap();
-    println!("{:?}", data_ser);
     let data_de_ipld: Ipld = serde_ipld_dagcbor::from_slice(&data_ser).unwrap();
 
     let strt: StructWithTupleSerialization = ipld_core::serde::from_ipld(data_de_ipld).unwrap();

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -124,7 +124,6 @@ fn test_ip_addr() {
 
     let addr = Ipv4Addr::new(8, 8, 8, 8);
     let vec = to_vec(&addr).unwrap();
-    println!("{:?}", vec);
     assert_eq!(vec.len(), 5);
     let test_addr: Ipv4Addr = from_slice(&vec).unwrap();
     assert_eq!(addr, test_addr);


### PR DESCRIPTION
Print statements make sense for debugging, but else they are just noise. Also one of them lead to a Clippy warning. Hence removing all of them.