### PR TITLE
fix: error on decoding 32-bit floats

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -364,6 +364,7 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
                     de.reader.advance(1);
                     visitor.visit_none()
                 }
+                #[cfg(feature = "less-strict-decoding")]
                 marker::F32 => de.deserialize_f32(visitor),
                 marker::F64 => de.deserialize_f64(visitor),
                 _ => Err(DecodeError::Unsupported { name, found: byte }),
@@ -403,13 +404,11 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
         let name = "f32";
         // DAG-CBOR strictly requires all floats to be encoded as f64.
         // When deserializing to f32, we need to handle f64 encoding.
-        // We also accept f32 encoding, although a strict DAG-CBOR
-        // implementation should reject it (please don't write new data
-        // with f32 encoding).
         let byte = peek_one(name, &mut self.reader)?;
         match byte {
+            // f32 encoding is not valid in strict DAG-CBOR.
+            #[cfg(feature = "less-strict-decoding")]
             marker::F32 => {
-                // Note: f32 encoding is not valid in strict DAG-CBOR.
                 let value = <f32>::decode(&mut self.reader)?;
                 // DAG-CBOR forbids NaN and Infinity.
                 if !value.is_finite() {

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -185,6 +185,52 @@ fn test_float() {
 }
 
 #[test]
+fn test_float_encoded_as_non_f64_ipld() {
+    // Supporting f16 would need extra work and was never supported. Hence they even fail in less
+    // strict decoding mode.
+    let ipld_f16: Result<Ipld, _> = de::from_slice(&[0xf9, 0x3e, 0x00]);
+    assert!(matches!(
+        ipld_f16.unwrap_err(),
+        DecodeError::Unsupported { .. }
+    ));
+
+    let ipld_f32: Result<Ipld, _> = de::from_slice(&[0xfa, 0x3f, 0xc0, 0x00, 0x00]);
+    #[cfg(not(feature = "less-strict-decoding"))]
+    assert!(matches!(
+        ipld_f32.unwrap_err(),
+        DecodeError::Unsupported { .. }
+    ));
+    #[cfg(feature = "less-strict-decoding")]
+    assert_eq!(ipld_f32.unwrap(), Ipld::Float(1.5));
+}
+
+#[test]
+fn test_float_to_f32() {
+    // A value encoded as CBOR 32-bit float is only available in the less strict mode.
+    let result_f32: Result<f32, _> = de::from_slice(&[0xfa, 0x3f, 0xc0, 0x00, 0x00]);
+    #[cfg(not(feature = "less-strict-decoding"))]
+    assert!(matches!(
+        result_f32.unwrap_err(),
+        DecodeError::Mismatch {
+            name: "f32",
+            found: 250
+        }
+    ));
+    #[cfg(feature = "less-strict-decoding")]
+    assert_eq!(result_f32.unwrap(), 1.5);
+
+    // A CBOR 64-bit float value that fits into a f32 without loss can be converted.
+    let result_no_loss: Result<f32, _> =
+        de::from_slice(&[0xfb, 0x3f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    assert_eq!(result_no_loss.unwrap(), 1.5);
+
+    // A CBOR 64-bit float value that does *not* fit into a f32 without loss should always fail.
+    let result_loss: Result<f32, _> =
+        de::from_slice(&[0xfb, 0x40, 0x11, 0x21, 0xa8, 0x01, 0x86, 0x24, 0xe3]);
+    assert!(matches!(result_loss.unwrap_err(), DecodeError::Msg { .. }));
+}
+
+#[test]
 fn test_rejected_tag() {
     // Tag 42, but not minimally encoded.
     let ipld: Result<Ipld, _> = de::from_slice(&[0xd9, 0x00, 0x2a, 0x43, 0x00, 0x01, 0x02]);

--- a/tests/std_types.rs
+++ b/tests/std_types.rs
@@ -206,25 +206,6 @@ fn test_f32_encoding_is_f64() {
 }
 
 #[test]
-fn test_accept_f32_cbor_marker_for_compatibility() {
-    // Test that we accept CBOR f32 encoding (0xfa marker) for compatibility,
-    // even though it's not valid in strict DAG-CBOR (please don't take this
-    // test as permission to use f32 encoding in new data!).
-
-    // Manually construct CBOR with f32 encoding
-    // 0xfa = f32 marker, followed by 4 bytes of IEEE 754 single precision
-    let f32_cbor = vec![
-        0xfa, // f32 marker (not valid in strict DAG-CBOR, but we accept it)
-        0x3f, 0xc0, 0x00, 0x00, // 1.5 in IEEE 754 single precision
-    ];
-
-    // Should successfully decode for compatibility
-    let result: Result<f32, _> = from_slice(&f32_cbor);
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), 1.5f32);
-}
-
-#[test]
 fn test_f32_strict_precision_rejection() {
     // Test that f64 values with more precision than f32 can represent are rejected
     // when deserializing to f32


### PR DESCRIPTION
By default, don't allow 32-bit CBOR floats to be decoded. 64-bit is DAG-CBORs only supported float type.

This was brought up at
https://github.com/ipld/serde_ipld_dagcbor/issues/61#issuecomment-4824302099 Thanks!