### PR TITLE
fix: reject -0.0

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -425,6 +425,12 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
                     return Err(DecodeError::Mismatch { name, found: byte });
                 }
 
+                // DAG-CBOR requires -0.0 to be encoded as 0.0.
+                #[cfg(not(feature = "less-strict-decoding"))]
+                if value == 0.0 && value.is_sign_negative() {
+                    return Err(DecodeError::Mismatch { name, found: byte });
+                }
+
                 let f32_value = value as f32;
 
                 // Check if conversion causes overflow to infinity
@@ -459,6 +465,11 @@ impl<'de, R: dec::Read<'de>> serde::Deserializer<'de> for &mut Deserializer<R> {
         let value = <f64>::decode(&mut self.reader)?;
         // DAG-CBOR forbids NaN and Infinity.
         if !value.is_finite() {
+            return Err(DecodeError::Mismatch { name, found: byte });
+        }
+        // DAG-CBOR requires -0.0 to be encoded as 0.0.
+        #[cfg(not(feature = "less-strict-decoding"))]
+        if value == 0.0 && value.is_sign_negative() {
             return Err(DecodeError::Mismatch { name, found: byte });
         }
         visitor.visit_f64(value)

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -137,6 +137,8 @@ impl<'a, W: enc::Write> serde::Serializer for &'a mut Serializer<W> {
                 "Float must be a finite number, not Infinity or NaN".into(),
             ))
         } else {
+            // -0.0 and 0.0 are equal, always encode as 0.0 (0x0000000000000000).
+            let v = if v == -0.0 { 0.0 } else { v };
             v.encode(&mut self.writer)?;
             Ok(())
         }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -185,6 +185,37 @@ fn test_float() {
 }
 
 #[test]
+fn test_float_negative_zero() {
+    // -0.0 (0x8000000000000000) must be encoded as 0.0, so decoding it is only allowed in the less
+    // strict mode.
+    let bytes = [0xfb, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+    let result: Result<f64, _> = de::from_slice(&bytes);
+    #[cfg(not(feature = "less-strict-decoding"))]
+    assert!(matches!(
+        result.unwrap_err(),
+        DecodeError::Mismatch {
+            name: "f64",
+            found: 251
+        }
+    ));
+    #[cfg(feature = "less-strict-decoding")]
+    assert_eq!(result.unwrap().to_bits(), (-0.0f64).to_bits());
+
+    let result_f32: Result<f32, _> = de::from_slice(&bytes);
+    #[cfg(not(feature = "less-strict-decoding"))]
+    assert!(matches!(
+        result_f32.unwrap_err(),
+        DecodeError::Mismatch {
+            name: "f32",
+            found: 251
+        }
+    ));
+    #[cfg(feature = "less-strict-decoding")]
+    assert_eq!(result_f32.unwrap().to_bits(), (-0.0f32).to_bits());
+}
+
+#[test]
 fn test_float_encoded_as_non_f64_ipld() {
     // Supporting f16 would need extra work and was never supported. Hence they even fail in less
     // strict decoding mode.

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -57,6 +57,18 @@ fn test_f32() {
 }
 
 #[test]
+fn test_negative_zero() {
+    // -0.0 and 0.0 are equal, -0.0 is encoded as 0.0 (0x0000000000000000).
+    let neg = to_vec(&-0.0f64).unwrap();
+    assert_eq!(neg, b"\xfb\x00\x00\x00\x00\x00\x00\x00\x00");
+    assert_eq!(neg, to_vec(&0.0f64).unwrap());
+
+    // The same is true when serializing an f32.
+    let neg_f32 = to_vec(&-0.0f32).unwrap();
+    assert_eq!(neg_f32, b"\xfb\x00\x00\x00\x00\x00\x00\x00\x00");
+}
+
+#[test]
 fn test_infinity() {
     let vec = to_vec(&f32::INFINITY);
     assert!(vec.is_err(), "Only finite numbers are supported.");

--- a/tests/std_types.rs
+++ b/tests/std_types.rs
@@ -175,7 +175,6 @@ fn test_f32_roundtrip() {
     // Test various f32 values
     let test_values = vec![
         0.0f32,
-        -0.0f32,
         1.0f32,
         -1.0f32,
         1.5f32,
@@ -245,13 +244,12 @@ fn test_f32_strict_precision_rejection() {
     assert!(decoded.is_ok());
     assert_eq!(decoded.unwrap(), original);
 
-    // Negative zero should preserve sign bit and work
+    // Negative zero is encoded as positive zero (0x0000000000000000).
     let neg_zero_f64 = -0.0f64;
     let encoded = to_vec(&neg_zero_f64).expect("encoding should succeed");
+    assert_eq!(encoded, to_binary("fb0000000000000000"));
     let result: Result<f32, _> = from_slice(&encoded);
     assert!(result.is_ok());
     let decoded_f32 = result.unwrap();
-    assert_eq!(decoded_f32, -0.0f32);
-    // Check that sign bit is preserved
-    assert_eq!(decoded_f32.to_bits(), (-0.0f32).to_bits());
+    assert_eq!(decoded_f32.to_bits(), (0.0f32).to_bits());
 }


### PR DESCRIPTION
For IEEE 754 floats `-0.0` is equal to `0.0`. It makes sense to have only a single representation for the same numbers, hence always encode it as `0.0`, i.e. `0x0000000000000000`.