### PR TITLE
fix: set MSRV to 1.81

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ license = "MIT/Apache-2.0"
 description = "IPLD DAG-CBOR support for Serde."
 keywords = ["serde", "cbor", "serialization", "no_std"]
 categories = ["encoding"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.81"
 
 [dependencies]
 cbor4ii = { version = "1.2.2", default-features = false, features = ["use_alloc"] }
-ipld-core = { version = "0.4.2", default-features = false, features = ["serde"] }
+ipld-core = { version = "0.4.2", default-features = false, features = ["serde", "codec"] }
 scopeguard = { version = "1.1.0", default-features = false }
 serde = { version = "1.0.164", default-features = false, features = ["alloc"] }
 
@@ -30,10 +31,8 @@ serde_tuple = "1.1.0"
 serde = { version = "1.0.164", default-features = false, features = ["rc"] }
 
 [features]
-default = ["codec", "std"]
+default = ["std"]
 std = ["cbor4ii/use_std", "ipld-core/std", "serde/std", "serde_bytes/std"]
-# Enable the `Codec` trait implementation. It's a separate feature as it needs Rust >= 1.75.
-codec = ["ipld-core/codec"]
 # Prevent deserializing CIDs as bytes as much as possible.
 no-cid-as-bytes = []
 # Don't be as strict on decoding data as on the encoding side.

--- a/README.md
+++ b/README.md
@@ -70,11 +70,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 Features
 --------
 
-### `codec`
-
-The `codec` feature is enabled by default, it provides the `Codec` trait, which enables encoding and decoding independent of the IPLD Codec. The minimum supported Rust version (MSRV) can significantly be reduced to 1.64 by disabling this feature.
-
-
 ### `less-strict-decoding`
 
 The decoding of data is as strict as possible. When enabling this feature, it's a bit less strict. If you run into decoding errors for your not fully DAG-CBOR compliant data, try this feature flag first.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ extern crate alloc;
 mod cbor4ii_nonpub;
 // The `Codec` implementation is only available if the `no-cid-as-bytes` feature is disabled, due
 // to the links being extracted with a Serde based approach.
-#[cfg(all(feature = "std", not(feature = "no-cid-as-bytes"), feature = "codec"))]
+#[cfg(all(feature = "std", not(feature = "no-cid-as-bytes")))]
 pub mod codec;
 pub mod de;
 pub mod error;

--- a/tests/std_types.rs
+++ b/tests/std_types.rs
@@ -3,7 +3,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_ipld_dagcbor::{from_slice, to_vec};
 
 fn to_binary(s: &'static str) -> Vec<u8> {
-    assert!(s.len().is_multiple_of(2));
+    assert!(s.len() % 2 == 0);
     let mut b = Vec::with_capacity(s.len() / 2);
     for i in 0..s.len() / 2 {
         b.push(u8::from_str_radix(&s[i * 2..(i + 1) * 2], 16).unwrap());


### PR DESCRIPTION
The cbor4ii crate has a minumum supported Rust version of 1.81, hence do we.

This makes it possible to remove the `codec` feature and just have those traits always implemented.

Also switch to the Rust 2021 edition.